### PR TITLE
Aisv614 fix

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -17,6 +17,7 @@ Changed Semantic Segmentation to take a SemanticSegmentationLabelConfig, which m
 ### Removed
 
 ### Fixed
+Fixed bug that prevented RGB captures to be written out to disk
 
 ### Security
 

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -171,9 +171,7 @@ namespace UnityEngine.Perception.GroundTruth
                 using (s_WriteFrame.Auto())
                 {
                     var dataColorBuffer = (byte[])r.data.colorBuffer;
-                    if (flipY)
-                        FlipImageY(dataColorBuffer, height);
-
+                    
                     byte[] encodedData;
                     using (s_EncodeAndSave.Auto())
                     {
@@ -184,7 +182,7 @@ namespace UnityEngine.Perception.GroundTruth
                 }
             };
 
-            CaptureCamera.Capture(cam, colorFunctor);
+            CaptureCamera.Capture(cam, colorFunctor, flipY: flipY);
 
             Profiler.EndSample();
         }
@@ -203,28 +201,6 @@ namespace UnityEngine.Perception.GroundTruth
 #else
             return false;
 #endif
-        }
-
-        static unsafe void FlipImageY(byte[] dataColorBuffer, int height)
-        {
-            using (s_FlipY.Auto())
-            {
-                var stride = dataColorBuffer.Length / height;
-                var buffer = new NativeArray<byte>(stride, Allocator.TempJob, NativeArrayOptions.UninitializedMemory);
-                fixed(byte* colorBufferPtr = &dataColorBuffer[0])
-                {
-                    var unsafePtr = (byte*)buffer.GetUnsafePtr();
-                    for (var row = 0; row < height / 2; row++)
-                    {
-                        var nearRowStartPtr = colorBufferPtr + stride * row;
-                        var oppositeRowStartPtr = colorBufferPtr + stride * (height - row - 1);
-                        UnsafeUtility.MemCpy(unsafePtr, oppositeRowStartPtr, stride);
-                        UnsafeUtility.MemCpy(oppositeRowStartPtr, nearRowStartPtr, stride);
-                        UnsafeUtility.MemCpy(nearRowStartPtr, unsafePtr, stride);
-                    }
-                }
-                buffer.Dispose();
-            }
         }
 
         void OnSimulationEnding()


### PR DESCRIPTION
# Peer Review Information:
Fix for aisv-614. Fixes issue with RGB images not being captured and also errors being thrown every frame. Solution consists of removing our own version of flipY and use the one provided to us by capture camera.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.4

## Dev Testing:
**Tests Added**: 
<br>
**Package Tests (Pass/Fail)**: 
[X] - Make sure automation passes 
<br>
**Core Scenario Tested**: 
<br>
**At Risk Areas**: 
<br>
**Notes + Expectations**: 
