### PR TITLE
Fix warnings

### DIFF
--- a/TestProjects/PerceptionHDRP/Assets/csc.rsp
+++ b/TestProjects/PerceptionHDRP/Assets/csc.rsp
@@ -1,0 +1,1 @@
+-warnaserror+

--- a/TestProjects/PerceptionHDRP/Assets/csc.rsp.meta
+++ b/TestProjects/PerceptionHDRP/Assets/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b590f0b421136b44098ad7e92fc45f3e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/PerceptionURP/Assets/ExampleScripts/CustomAnnotationAndMetricReporter.cs
+++ b/TestProjects/PerceptionURP/Assets/ExampleScripts/CustomAnnotationAndMetricReporter.cs
@@ -5,7 +5,7 @@ using UnityEngine.Perception.GroundTruth;
 [RequireComponent(typeof(PerceptionCamera))]
 public class CustomAnnotationAndMetricReporter : MonoBehaviour
 {
-    public GameObject light;
+    public GameObject targetLight;
     public GameObject target;
 
     MetricDefinition lightMetricDefinition;
@@ -28,7 +28,7 @@ public class CustomAnnotationAndMetricReporter : MonoBehaviour
     public void Update()
     {
         //Report the light's position by manually creating the json array string.
-        var lightPos = light.transform.position;
+        var lightPos = targetLight.transform.position;
         DatasetCapture.ReportMetric(lightMetricDefinition,
             $@"[{{ ""x"": {lightPos.x}, ""y"": {lightPos.y}, ""z"": {lightPos.z} }}]");
         //compute the location of the object in the camera's local space

--- a/TestProjects/PerceptionURP/Assets/csc.rsp
+++ b/TestProjects/PerceptionURP/Assets/csc.rsp
@@ -1,0 +1,1 @@
+-warnaserror+

--- a/TestProjects/PerceptionURP/Assets/csc.rsp.meta
+++ b/TestProjects/PerceptionURP/Assets/csc.rsp.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1800f44b598c0b647bf3fad2f5c9b957
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+Fixed compilation warnings with latest com.unity.simulation.core package.
 
 ### Security
 

--- a/com.unity.perception/Documentation~/DatasetCapture.md
+++ b/com.unity.perception/Documentation~/DatasetCapture.md
@@ -26,7 +26,7 @@ using UnityEngine.Perception.GroundTruth;
 [RequireComponent(typeof(PerceptionCamera))]
 public class CustomAnnotationAndMetricReporter : MonoBehaviour
 {
-    public GameObject light;
+    public GameObject targetLight;
     public GameObject target;
 
     MetricDefinition lightMetricDefinition;
@@ -49,7 +49,7 @@ public class CustomAnnotationAndMetricReporter : MonoBehaviour
     public void Update()
     {
         //Report the light's position by manually creating the json array string.
-        var lightPos = light.transform.position;
+        var lightPos = targetLight.transform.position;
         DatasetCapture.ReportMetric(lightMetricDefinition,
             $@"[{{ ""x"": {lightPos.x}, ""y"": {lightPos.y}, ""z"": {lightPos.z} }}]");
         //compute the location of the object in the camera's local space

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
@@ -193,7 +193,7 @@ namespace UnityEngine.Perception.GroundTruth
                 height = targetTexture.height,
                 path = localPath
             };
-            asyncRequest.Start((r) =>
+            asyncRequest.Enqueue((r) =>
             {
                 Profiler.BeginSample("Encode");
                 var pngBytes = ImageConversion.EncodeArrayToPNG(r.data.data.ToArray(), GraphicsFormat.R8G8B8A8_UNorm, (uint)r.data.width, (uint)r.data.height);
@@ -205,6 +205,7 @@ namespace UnityEngine.Perception.GroundTruth
                 r.data.data.Dispose();
                 return AsyncRequest.Result.Completed;
             });
+            asyncRequest.Execute();
         }
 
         /// <inheritdoc/>

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -63,8 +63,11 @@ namespace UnityEngine.Perception.GroundTruth
 
         bool m_CapturedLastFrame;
         Ego m_EgoMarker;
+
+#pragma warning disable 414
         //only used to confirm that GroundTruthRendererFeature is present in URP
         bool m_GroundTruthRendererFeatureRun;
+#pragma warning restore 414
 
         /// <summary>
         /// The <see cref="SensorHandle"/> associated with this camera. Use this to report additional annotations and metrics at runtime.
@@ -171,7 +174,7 @@ namespace UnityEngine.Perception.GroundTruth
                 using (s_WriteFrame.Auto())
                 {
                     var dataColorBuffer = (byte[])r.data.colorBuffer;
-                    
+
                     byte[] encodedData;
                     using (s_EncodeAndSave.Auto())
                     {

--- a/com.unity.perception/Runtime/GroundTruth/SimulationState_Json.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SimulationState_Json.cs
@@ -188,11 +188,12 @@ namespace UnityEngine.Perception.GroundTruth
                     PendingCaptures = pendingCapturesToWrite,
                     SimulationState = this
                 };
-                req.Start(r =>
+                req.Enqueue(r =>
                 {
                     Write(r.data.PendingCaptures, r.data.SimulationState, r.data.CaptureFileIndex);
                     return AsyncRequest.Result.Completed;
                 });
+                req.Execute(AsyncRequest.ExecutionContext.JobSystem);
             }
 
             m_SerializeCapturesSampler.End();
@@ -256,11 +257,12 @@ namespace UnityEngine.Perception.GroundTruth
                     MetricFileIndex = m_MetricsFileIndex,
                     PendingMetrics = pendingMetricsToWrite
                 };
-                req.Start(r =>
+                req.Enqueue(r =>
                 {
                     Write(r.data.PendingMetrics, r.data.MetricFileIndex);
                     return AsyncRequest.Result.Completed;
                 });
+                req.Execute();
             }
 
             m_MetricsFileIndex++;

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/SegmentationGroundTruthTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/SegmentationGroundTruthTests.cs
@@ -5,15 +5,11 @@ using System.Linq;
 using NUnit.Framework;
 using Unity.Collections;
 using UnityEngine;
-using UnityEngine.Experimental.Rendering;
 using UnityEngine.Perception.GroundTruth;
 using UnityEngine.Rendering;
 #if HDRP_PRESENT
-using UnityEngine.Rendering.HighDefinition;
-using UnityEngine.Experimental.Rendering;
 #endif
 using UnityEngine.TestTools;
-using UnityEngine.UIElements;
 using Object = UnityEngine.Object;
 
 namespace GroundTruthTests
@@ -179,7 +175,6 @@ namespace GroundTruthTests
         [UnityTest]
         public IEnumerator SemanticSegmentationPass_WithTextureOverride_RendersToOverride()
         {
-            int timesSegmentationImageReceived = 0;
             var expectedPixelValue = new Color32(0, 0, 255, 255);
             var targetTextureOverride = new RenderTexture(2, 2, 1, RenderTextureFormat.R8);
 


### PR DESCRIPTION
# Peer Review Information:
Fix warnings in the package when using the latest com.unity.simulation.core package. Also fixes other warnings in the tests and test projects.

Enabled warnings as errors in both test projects using csc.rsp files so that we do not regress in warnings going forward.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
Enabled warnings as errors in the test projects.
<br>
**Package Tests (Pass/Fail)**: 
[X] - Make sure automation passes 
<br>
**Core Scenario Tested**: 
<br>
**At Risk Areas**: None
<br>
**Notes + Expectations**: 
