### PR TITLE
Fixing wrong colors in semantic segmentation 

### DIFF
--- a/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
@@ -128,11 +128,18 @@ namespace UnityEngine.Perception.GroundTruth
 
             m_AsyncAnnotations = new Dictionary<int, AsyncAnnotation>();
 
-            var renderTextureDescriptor = new RenderTextureDescriptor(width, height, GraphicsFormat.R8G8B8A8_UNorm, 8);
             if (targetTexture != null)
+            {
+                if (targetTexture.sRGB)
+                {
+                    Debug.LogError("targetTexture supplied to SemanticSegmentationLabeler must be in Linear mode. Disabling labeler.");
+                    this.enabled = false;
+                }
+                var renderTextureDescriptor = new RenderTextureDescriptor(width, height, GraphicsFormat.R8G8B8A8_UNorm, 8);
                 targetTexture.descriptor = renderTextureDescriptor;
+            }
             else
-                m_TargetTextureOverride = new RenderTexture(renderTextureDescriptor);
+                m_TargetTextureOverride = new RenderTexture(width, height, 8, RenderTextureFormat.ARGB32, RenderTextureReadWrite.Linear);
 
             targetTexture.Create();
             targetTexture.name = "Labeling";

--- a/com.unity.perception/Runtime/GroundTruth/Resources/SemanticSegmentation.shader
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/SemanticSegmentation.shader
@@ -2,7 +2,7 @@
 {
     Properties
     {
-        [PerObjectData] LabelingId("Labeling Id", Color) = (0,0,0,1)
+        [PerObjectData] LabelingId("Labeling Id", Vector) = (0,0,0,1)
     }
 
     HLSLINCLUDE

--- a/com.unity.perception/Runtime/GroundTruth/SemanticSegmentationCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SemanticSegmentationCrossPipelinePass.cs
@@ -69,7 +69,7 @@ namespace UnityEngine.Perception.GroundTruth
 
             //Set the labeling ID so that it can be accessed in ClassSemanticSegmentationPass.shader
             if (found)
-                mpb.SetColor(k_LabelingId, entry.color);
+                mpb.SetVector(k_LabelingId, entry.color);
         }
     }
 }

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/SegmentationGroundTruthTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/SegmentationGroundTruthTests.cs
@@ -44,7 +44,7 @@ namespace GroundTruthTests
     [UnityPlatform(exclude = new[] {RuntimePlatform.LinuxEditor, RuntimePlatform.LinuxPlayer})]
     public class SegmentationPassTests : GroundTruthTestBase
     {
-        static readonly Color32 k_SemanticPixelValue = Color.blue;
+        static readonly Color32 k_SemanticPixelValue = new Color32(10, 20, 30, Byte.MaxValue);
 
         public enum SegmentationKind
         {
@@ -232,7 +232,7 @@ namespace GroundTruthTests
                 catch (Exception)
                 {
                     //uncomment to get RenderDoc captures while this check is failing
-                    //RenderDoc.EndCaptureRenderDoc(gameView);
+                    //UnityEditorInternal.RenderDoc.EndCaptureRenderDoc(gameView);
                     throw;
                 }
             }


### PR DESCRIPTION
# Peer Review Information:
Fixing wrong colors in semantic segmentation due to sRGB conversion by changing the shader parameter to a Vector, bypassing sRGB conversion altogether.

Fixes #44 

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
Updated semantic segmentation tests to use a color that would be affected by sRGB <->Linear color conversions
<br>
**Package Tests (Pass/Fail)**: 
[X] - Make sure automation passes 
<br>
**Core Scenario Tested**: 
<br>
**At Risk Areas**: 
<br>
**Notes + Expectations**: 
