### PR TITLE
Bug fix for visualization memory leak

### DIFF
--- a/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
@@ -123,6 +123,7 @@ namespace UnityEngine.Perception.GroundTruth
 
         private GameObject segVisual = null;
         private RawImage segImage = null;
+        private Texture2D m_CpuTexture = null;
 
         /// <inheritdoc/>
         protected override bool supportsVisualization => true;
@@ -252,6 +253,12 @@ namespace UnityEngine.Perception.GroundTruth
                 m_TargetTextureOverride.Release();
 
             m_TargetTextureOverride = null;
+
+            if (m_CpuTexture != null)
+            {
+                Object.Destroy(m_CpuTexture);
+                m_CpuTexture = null;
+            }
         }
 
         /// <inheritdoc/>
@@ -285,10 +292,12 @@ namespace UnityEngine.Perception.GroundTruth
 
         void VisualizeSegmentationTexture(NativeArray<Color32> data, RenderTexture texture)
         {
-            var cpuTexture = new Texture2D(texture.width, texture.height, GraphicsFormat.R8G8B8A8_UNorm, TextureCreationFlags.None);
-            cpuTexture.LoadRawTextureData(data);
-            cpuTexture.Apply();
-            segImage.texture = cpuTexture;
+            if (m_CpuTexture == null)
+                m_CpuTexture = new Texture2D(texture.width, texture.height, GraphicsFormat.R8G8B8A8_UNorm, TextureCreationFlags.None);
+
+            m_CpuTexture.LoadRawTextureData(data);
+            m_CpuTexture.Apply();
+            segImage.texture = m_CpuTexture;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
I was reallocating a texture2D each frame. Changed it to re-use a member Texture2D and properly clean up allocated texture at program complete

# Peer Review Information:
Information on any code, feature, documentation changes here

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
<br>
**Package Tests (Pass/Fail)**: 
[X] - Make sure automation passes 
<br>
**Core Scenario Tested**: 
<br>
**At Risk Areas**: 
<br>
**Notes + Expectations**: 
