### PR TITLE
Segmentation Alpha Bug Fix

### DIFF
--- a/com.unity.perception/Runtime/GroundTruth/Labelers/Visualization/Resources/SegRemoveBackgroundShader.shader
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/Visualization/Resources/SegRemoveBackgroundShader.shader
@@ -53,18 +53,10 @@
                 // sample the texture
                 fixed4 col = tex2D(_MainTex, i.uv);
 
-                if (abs(col.r - _RemoveColor.r) < .01f)
-                {
-                    if (abs(col.g - _RemoveColor.g) < .01f)
-                    {
-                        if (abs(col.b - _RemoveColor.b) < .01f)
-                        {
-                            col.a = _BackTransparency;
-                        }
-                    }
-                }
-
-                if (abs(col.a - _BackTransparency) > .01f) col.a = _SegmentTransparency;
+                if (abs(col.r - _RemoveColor.r) < .001f && abs(col.g - _RemoveColor.g) < .001f && abs(col.b - _RemoveColor.b) < .001f)
+                    col.a = _BackTransparency;
+                else
+                    col.a = _SegmentTransparency;
 
                 return col;
             }


### PR DESCRIPTION
Capped the max opacity allowed in the shader to an extremely high value (0.995) to stop a weird issue caused by alpha being set to 1.0

# Peer Review Information:
Information on any code, feature, documentation changes here

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
<br>
**Package Tests (Pass/Fail)**: 
[X] - Make sure automation passes 
<br>
**Core Scenario Tested**: 
<br>
**At Risk Areas**: 
<br>
**Notes + Expectations**: 
