### PR TITLE
Fixing LabelEntryMatchCache 

### DIFF
--- a/com.unity.perception/Runtime/GroundTruth/GroundTruthLabelSetupSystem.cs
+++ b/com.unity.perception/Runtime/GroundTruth/GroundTruthLabelSetupSystem.cs
@@ -53,6 +53,7 @@ namespace UnityEngine.Perception.GroundTruth
                 {
                     instanceId = instanceId
                 });
+                labeling.SetInstanceId(instanceId);
             });
         }
 

--- a/com.unity.perception/Runtime/GroundTruth/Labeling/IdLabelEntry.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labeling/IdLabelEntry.cs
@@ -5,7 +5,7 @@ namespace UnityEngine.Perception.GroundTruth {
     /// An entry for <see cref="IdLabelConfig"/> mapping a label to an integer id.
     /// </summary>
     [Serializable]
-    public struct IdLabelEntry : ILabelEntry
+    public struct IdLabelEntry : ILabelEntry, IEquatable<IdLabelEntry>
     {
         string ILabelEntry.label => this.label;
         /// <summary>
@@ -16,5 +16,26 @@ namespace UnityEngine.Perception.GroundTruth {
         /// The id to associate with the label.
         /// </summary>
         public int id;
+
+        /// <inheritdoc/>
+        public bool Equals(IdLabelEntry other)
+        {
+            return label == other.label && id == other.id;
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return obj is IdLabelEntry other && Equals(other);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((label != null ? label.GetHashCode() : 0) * 397) ^ id;
+            }
+        }
     }
 }

--- a/com.unity.perception/Runtime/GroundTruth/Labeling/LabelEntryMatchCache.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labeling/LabelEntryMatchCache.cs
@@ -14,6 +14,7 @@ namespace UnityEngine.Perception.GroundTruth
         const int k_StartingObjectCount = 1 << 8;
         NativeList<ushort> m_InstanceIdToLabelEntryIndexLookup;
         IdLabelConfig m_IdLabelConfig;
+        ushort m_DefaultValue;
 
         public LabelEntryMatchCache(IdLabelConfig idLabelConfig)
         {
@@ -26,7 +27,7 @@ namespace UnityEngine.Perception.GroundTruth
         {
             labelEntry = default;
             index = -1;
-            if (m_InstanceIdToLabelEntryIndexLookup.Length <= instanceId)
+            if (m_InstanceIdToLabelEntryIndexLookup.Length <= instanceId || m_InstanceIdToLabelEntryIndexLookup[(int)instanceId] == m_DefaultValue)
                 return false;
 
             index = m_InstanceIdToLabelEntryIndexLookup[(int)instanceId];
@@ -38,9 +39,15 @@ namespace UnityEngine.Perception.GroundTruth
         {
             if (m_IdLabelConfig.TryGetMatchingConfigurationEntry(labeling, out _, out var index))
             {
+                m_DefaultValue = ushort.MaxValue;
+                Debug.Assert(index < m_DefaultValue, "Too many entries in the label config");
                 if (m_InstanceIdToLabelEntryIndexLookup.Length <= instanceId)
                 {
+                    var oldLength = m_InstanceIdToLabelEntryIndexLookup.Length;
                     m_InstanceIdToLabelEntryIndexLookup.Resize((int)instanceId + 1, NativeArrayOptions.ClearMemory);
+
+                    for (int i = oldLength; i < instanceId; i++)
+                        m_InstanceIdToLabelEntryIndexLookup[i] = m_DefaultValue;
                 }
                 m_InstanceIdToLabelEntryIndexLookup[(int)instanceId] = (ushort)index;
             }

--- a/com.unity.perception/Runtime/GroundTruth/Labeling/Labeling.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labeling/Labeling.cs
@@ -17,7 +17,14 @@ namespace UnityEngine.Perception.GroundTruth
         [FormerlySerializedAs("classes")]
         public List<string> labels = new List<string>();
 
+        public uint instanceId { get; private set; }
+
         Entity m_Entity;
+
+        internal void SetInstanceId(uint instanceId)
+        {
+            this.instanceId = instanceId;
+        }
         void Awake()
         {
             m_Entity = World.DefaultGameObjectInjectionWorld.EntityManager.CreateEntity();

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/LabelEntryMatchCacheTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/LabelEntryMatchCacheTests.cs
@@ -1,0 +1,93 @@
+﻿using System.Collections;
+using NUnit.Framework;
+using UnityEngine.Perception.GroundTruth;
+using UnityEngine.TestTools;
+
+namespace GroundTruthTests
+{
+    [TestFixture]
+    public class LabelEntryMatchCacheTests : GroundTruthTestBase
+    {
+        [Test]
+        public void TryGet_ReturnsFalse_ForInvalidInstanceId()
+        {
+            var config = new IdLabelConfig();
+            using (var cache = new LabelEntryMatchCache(config))
+            {
+                Assert.IsFalse(cache.TryGetLabelEntryFromInstanceId(100, out var labelEntry, out var index));
+                Assert.AreEqual(-1, index);
+                Assert.AreEqual(default(IdLabelEntry), labelEntry);
+            }
+        }
+        [UnityTest]
+        public IEnumerator TryGet_ReturnsTrue_ForMatchingLabel()
+        {
+            var label = "label";
+            var labeledPlane = TestHelper.CreateLabeledPlane(label: label);
+            AddTestObjectForCleanup(labeledPlane);
+            var config = new IdLabelConfig();
+            config.Init(new[]
+            {
+                new IdLabelEntry()
+                {
+                    id = 1,
+                    label = label
+                },
+            });
+            using (var cache = new LabelEntryMatchCache(config))
+            {
+                //allow label to be registered
+                yield return null;
+                Assert.IsTrue(cache.TryGetLabelEntryFromInstanceId(labeledPlane.GetComponent<Labeling>().instanceId, out var labelEntry, out var index));
+                Assert.AreEqual(0, index);
+                Assert.AreEqual(config.labelEntries[0], labelEntry);
+            }
+        }
+        [UnityTest]
+        public IEnumerator TryGet_ReturnsFalse_ForNonMatchingLabel()
+        {
+            var label = "label";
+            var labeledPlane = TestHelper.CreateLabeledPlane(label: label);
+            AddTestObjectForCleanup(labeledPlane);
+            var config = new IdLabelConfig();
+            using (var cache = new LabelEntryMatchCache(config))
+            {
+                //allow label to be registered
+                yield return null;
+                Assert.IsFalse(cache.TryGetLabelEntryFromInstanceId(labeledPlane.GetComponent<Labeling>().instanceId, out var labelEntry, out var index));
+                Assert.AreEqual(-1, index);
+                Assert.AreEqual(default(IdLabelEntry), labelEntry);
+            }
+        }
+        [UnityTest]
+        public IEnumerator TryGet_ReturnsFalse_ForNonMatchingLabel_WithOtherMatches()
+        {
+            var label = "label";
+            //only way to guarantee registration order is to run frames.
+            //We want to ensure labeledPlane is registered before labeledPlane2 so that the cache does not early out
+            var labeledPlane = TestHelper.CreateLabeledPlane(label: "foo");
+            AddTestObjectForCleanup(labeledPlane);
+            yield return null;
+            var labeledPlane2 = TestHelper.CreateLabeledPlane(label: label);
+            AddTestObjectForCleanup(labeledPlane2);
+            var config = new IdLabelConfig();
+            config.Init(new[]
+            {
+                new IdLabelEntry()
+                {
+                    id = 1,
+                    label = label
+                },
+            });
+            using (var cache = new LabelEntryMatchCache(config))
+            {
+                //allow label to be registered
+                yield return null;
+                Assert.IsFalse(cache.TryGetLabelEntryFromInstanceId(labeledPlane.GetComponent<Labeling>().instanceId, out var labelEntry, out var index));
+                Assert.AreEqual(-1, index);
+                Assert.AreEqual(default(IdLabelEntry), labelEntry);
+            }
+        }
+
+    }
+}

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/LabelEntryMatchCacheTests.cs.meta
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/LabelEntryMatchCacheTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8404035e89b3b1b4e87136d8a512b6f5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Peer Review Information:
Fixing bug where instance ids that do not match any IdLabelConfig entries are reported as matching the first entry, resulting in bounding boxes being drawn around objects whose labels have no matches in the IdLabelConfig.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
Adding tests for LabelEntryMatchCache
<br>
**Package Tests (Pass/Fail)**: 
[X] - Make sure automation passes 
<br>
**Core Scenario Tested**: 
<br>
**At Risk Areas**: 
<br>
**Notes + Expectations**: 
