### PR TITLE
Better hashing used for iterating random sampler states

### DIFF
--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
@@ -71,7 +71,7 @@ namespace UnityEngine.Perception.Randomization.Samplers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint IterateSeed(uint index, uint baseSeed)
         {
-            return (uint)Hash64(((ulong)index << 32) | baseSeed) << 1 | 1u;
+            return (uint)Hash64(((ulong)index << 32) | baseSeed) | 1u;
         }
 
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
@@ -71,7 +71,7 @@ namespace UnityEngine.Perception.Randomization.Samplers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint IterateSeed(uint index, uint baseSeed)
         {
-            return (uint)Hash64((ulong)index << 32 | baseSeed) << 1 | 1u;
+            return (uint)Hash64(((ulong)index << 32) | baseSeed) << 1 | 1u;
         }
 
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
@@ -71,8 +71,7 @@ namespace UnityEngine.Perception.Randomization.Samplers
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static uint IterateSeed(uint index, uint baseSeed)
         {
-            var seedLeftSide = (ulong)index << 32;
-            return (uint)Hash64(seedLeftSide | baseSeed) << 1 | 1u;
+            return (uint)Hash64((ulong)index << 32 | baseSeed) << 1 | 1u;
         }
 
         /// <summary>


### PR DESCRIPTION
# Peer Review Information:
This PR addresses two points:
1. A bug caused by certain combinations of seeds and indices generating a random state of zero. The Random struct of Unity.Mathematics uses an XOR shift based Next() method that errors on zero valued random states. This update will ensure that samplers will iterate to non-zero random states for any potential scenario iteration.
2. The need for a better hash function to maximize the avalanche effect, independence of output bit changes, and the probability of a change in each output bit if any input bit is changed when generating new initial random states

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Notes**: 
Aside from testing all possible combinations of seeds and indices, a quick examination of the IterateSeed method will illustrate that the final bitwise OR operator ensures that all generated states will be non-zero