### PR TITLE
Do not generate any empty folders if the PerceptionCamera is never enabled

### DIFF
--- a/com.unity.perception/Runtime/GroundTruth/DatasetCapture.cs
+++ b/com.unity.perception/Runtime/GroundTruth/DatasetCapture.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using JetBrains.Annotations;
 using Newtonsoft.Json.Linq;
 using Unity.Simulation;
@@ -16,7 +17,7 @@ namespace UnityEngine.Perception.GroundTruth
         static readonly Guid k_DatasetGuid = Guid.NewGuid();
         internal static SimulationState SimulationState { get; private set; } = CreateSimulationData();
 
-        internal static string OutputDirectory => SimulationState.OutputDirectory;
+        internal static string OutputDirectory => SimulationState.GetOutputDirectoryNoCreate();
 
         /// <summary>
         /// The json metadata schema version the DatasetCapture's output conforms to.
@@ -159,7 +160,7 @@ namespace UnityEngine.Perception.GroundTruth
         static SimulationState CreateSimulationData()
         {
             //TODO: Remove the Guid path when we have proper dataset merging in USim/Thea
-            return new SimulationState(Manager.Instance.GetDirectoryFor($"Dataset{k_DatasetGuid}"));
+            return new SimulationState($"Dataset{k_DatasetGuid}");
         }
 
         [RuntimeInitializeOnLoadMethod]

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -89,6 +89,7 @@ namespace UnityEngine.Perception.GroundTruth
         }
 
         SensorHandle m_SensorHandle;
+        Ego m_EgoMarker;
 
         static ProfilerMarker s_WriteFrame = new ProfilerMarker("Write Frame (PerceptionCamera)");
         static ProfilerMarker s_EncodeAndSave = new ProfilerMarker("Encode and save (PerceptionCamera)");
@@ -144,8 +145,8 @@ namespace UnityEngine.Perception.GroundTruth
         {
             if (m_SensorHandle.IsNil)
             {
-                Ego egoMarker = this.GetComponentInParent<Ego>();
-                var ego = egoMarker == null ? DatasetCapture.RegisterEgo("") : egoMarker.EgoHandle;
+                m_EgoMarker = GetComponentInParent<Ego>();
+                var ego = m_EgoMarker == null ? DatasetCapture.RegisterEgo("") : m_EgoMarker.EgoHandle;
                 SensorHandle = DatasetCapture.RegisterSensor(ego, "camera", description, period, startTime);
             }
         }
@@ -228,6 +229,7 @@ namespace UnityEngine.Perception.GroundTruth
         // Update is called once per frame
         void Update()
         {
+            EnsureSensorRegistered();
             if (!SensorHandle.IsValid)
                 return;
 
@@ -276,8 +278,7 @@ namespace UnityEngine.Perception.GroundTruth
 
             var captureFilename = $"{Manager.Instance.GetDirectoryFor(RgbDirectory)}/{s_RgbFilePrefix}{Time.frameCount}.png";
             var dxRootPath = $"{RgbDirectory}/{s_RgbFilePrefix}{Time.frameCount}.png";
-            Ego egoMarker = this.GetComponentInParent<Ego>();
-            SensorHandle.ReportCapture(dxRootPath, SensorSpatialData.FromGameObjects(egoMarker == null ? null : egoMarker.gameObject, gameObject), m_PersistentSensorData.Select(kvp => (kvp.Key, kvp.Value)).ToArray());
+            SensorHandle.ReportCapture(dxRootPath, SensorSpatialData.FromGameObjects(m_EgoMarker == null ? null : m_EgoMarker.gameObject, gameObject), m_PersistentSensorData.Select(kvp => (kvp.Key, kvp.Value)).ToArray());
 
             Func<AsyncRequest<CaptureCamera.CaptureState>, AsyncRequest.Result> colorFunctor;
             var width = cam.pixelWidth;


### PR DESCRIPTION
# Peer Review Information:
Do not generate any empty folders if the PerceptionCamera is never enabled and no other dataset generation APIs are called.
Fixes AISV-719

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
Added test
<br>
**Package Tests (Pass/Fail)**: 
[X] - Make sure automation passes 
<br>
**Core Scenario Tested**: 
<br>
**At Risk Areas**: 
<br>
**Notes + Expectations**: 
