### PR TITLE
Fix exceptions in non-development players

### DIFF
--- a/TestProjects/PerceptionURP/Assets/Scenes/SampleScene.unity
+++ b/TestProjects/PerceptionURP/Assets/Scenes/SampleScene.unity
@@ -375,7 +375,6 @@ GameObject:
   m_Component:
   - component: {fileID: 705507995}
   - component: {fileID: 705507994}
-  - component: {fileID: 705507996}
   m_Layer: 0
   m_Name: Directional Light
   m_TagString: Untagged
@@ -458,18 +457,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!114 &705507996
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 705507993}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 7a68c43fe1f2a47cfa234b5eeaa98012, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &963194225
 GameObject:
   m_ObjectHideFlags: 0
@@ -484,7 +471,6 @@ GameObject:
   - component: {fileID: 963194229}
   - component: {fileID: 963194227}
   - component: {fileID: 963194231}
-  - component: {fileID: 963194232}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -609,7 +595,7 @@ MonoBehaviour:
   - id: 1
   - id: 2
   - id: 3
-  showVisualizations: 1
+  showVisualizations: 0
   references:
     version: 1
     00000000:
@@ -657,18 +643,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   targetLight: {fileID: 705507993}
   target: {fileID: 1640252278}
---- !u!114 &963194232
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 963194225}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 53f4c974fdf704444959724a41de0cfe, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1640252278
 GameObject:
   m_ObjectHideFlags: 0

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -71,7 +71,7 @@ namespace UnityEngine.Perception.GroundTruth
         [SerializeField]
         public bool showVisualizations = true;
 
-        bool m_ShowingVisualizations;
+        bool m_ShowingVisualizations = false;
 
         /// <summary>
         /// The <see cref="SensorHandle"/> associated with this camera. Use this to report additional annotations and metrics at runtime.
@@ -130,9 +130,8 @@ namespace UnityEngine.Perception.GroundTruth
             SetupInstanceSegmentation();
             var cam = GetComponent<Camera>();
 
-#if UNITY_EDITOR || DEVELOPMENT_BUILD
             SetupVisualizationCamera(cam);
-#endif
+
 
             DatasetCapture.SimulationEnding += OnSimulationEnding;
         }
@@ -157,6 +156,10 @@ namespace UnityEngine.Perception.GroundTruth
 
         void SetupVisualizationCamera(Camera cam)
         {
+#if !UNITY_EDITOR && !DEVELOPMENT_BUILD
+            showVisualizations = false;
+#else
+
             var visualizationAllowed = s_VisualizedPerceptionCamera == null;
 
             if (!visualizationAllowed && showVisualizations)
@@ -172,6 +175,7 @@ namespace UnityEngine.Perception.GroundTruth
             s_VisualizedPerceptionCamera = this;
 
             hudPanel = gameObject.AddComponent<HUDPanel>();
+#endif
         }
 
         void CheckForRendererFeature(ScriptableRenderContext context, Camera camera)


### PR DESCRIPTION
# Peer Review Information:
Non-development players were getting into a bad codepath where `showVisualizations` was true but the visualizations themselves were not initialized. This was causing exceptions in OpenGL for unknown reasons. This PR fixes the inconsistency.

I couldn't figure out how to add tests for this though, since I'm not sure how to run tests in OpenGL. Just manual testing for now.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
<br>
**Package Tests (Pass/Fail)**: 
[X] - Make sure automation passes 
<br>
**Core Scenario Tested**: 
Tested editor, development player, non-development player with visualizations enabled and disabled on each. 
<br>
**At Risk Areas**: 
<br>
**Notes + Expectations**: 
