### PR TITLE
No boxes on unmatching objects

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Removed
 
 ### Fixed
+Fixed 2d bounding boxes being reported for objects that do not match the label config.
 
 ### Security
 

--- a/com.unity.perception/Runtime/GroundTruth/DatasetCapture.cs
+++ b/com.unity.perception/Runtime/GroundTruth/DatasetCapture.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using JetBrains.Annotations;
 using Newtonsoft.Json.Linq;
+using Unity.Collections;
 using Unity.Simulation;
 using UnityEngine;
 
@@ -514,7 +516,21 @@ namespace UnityEngine.Perception.GroundTruth
         /// <param name="values">The annotation data.</param>
         /// <typeparam name="T">The type of the data.</typeparam>
         /// <exception cref="ArgumentNullException">Thrown if values is null</exception>
-        public void ReportValues<T>(T[] values)
+        public void ReportValues<T>(IEnumerable<T> values)
+        {
+            if (values == null)
+                throw new ArgumentNullException(nameof(values));
+
+            m_SimulationState.ReportAsyncAnnotationResult(this, values: values);
+        }
+
+        /// <summary>
+        /// Report a value-based data for this annotation.
+        /// </summary>
+        /// <param name="values">The annotation data.</param>
+        /// <typeparam name="T">The type of the data.</typeparam>
+        /// <exception cref="ArgumentNullException">Thrown if values is null</exception>
+        public void ReportValues<T>(NativeSlice<T> values) where T : struct
         {
             if (values == null)
                 throw new ArgumentNullException(nameof(values));

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/BoundingBoxLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/BoundingBoxLabeler.cs
@@ -42,7 +42,7 @@ namespace UnityEngine.Perception.GroundTruth
 
         Dictionary<int, AsyncAnnotation> m_AsyncAnnotations;
         AnnotationDefinition m_BoundingBoxAnnotationDefinition;
-        BoundingBoxValue[] m_BoundingBoxValues;
+        List<BoundingBoxValue> m_BoundingBoxValues;
 
         Vector2 m_OriginalScreenSize = Vector2.zero;
 
@@ -76,6 +76,7 @@ namespace UnityEngine.Perception.GroundTruth
                 throw new InvalidOperationException("BoundingBox2DLabeler's idLabelConfig field must be assigned");
 
             m_AsyncAnnotations = new Dictionary<int, AsyncAnnotation>();
+            m_BoundingBoxValues = new List<BoundingBoxValue>();
 
             m_BoundingBoxAnnotationDefinition = DatasetCapture.RegisterAnnotationDefinition("bounding box", idLabelConfig.GetAnnotationSpecification(),
                 "Bounding box for each labeled object visible to the sensor", id: new Guid(annotationId));
@@ -114,16 +115,14 @@ namespace UnityEngine.Perception.GroundTruth
 
             using (s_BoundingBoxCallback.Auto())
             {
-                if (m_BoundingBoxValues == null || m_BoundingBoxValues.Length != renderedObjectInfos.Length)
-                    m_BoundingBoxValues = new BoundingBoxValue[renderedObjectInfos.Length];
-
+                m_BoundingBoxValues.Clear();
                 for (var i = 0; i < renderedObjectInfos.Length; i++)
                 {
                     var objectInfo = renderedObjectInfos[i];
-                    if (!idLabelConfig.TryGetLabelEntryFromInstanceId(objectInfo.instanceId, out var labelEntry))
+                    if (!idLabelConfig.TryGetLabelEntryFromInstanceId(objectInfo.instanceId, out var labelEntry, out var index))
                         continue;
 
-                    m_BoundingBoxValues[i] = new BoundingBoxValue
+                    m_BoundingBoxValues.Add(new BoundingBoxValue
                     {
                         label_id = labelEntry.id,
                         label_name = labelEntry.label,
@@ -132,7 +131,7 @@ namespace UnityEngine.Perception.GroundTruth
                         y = objectInfo.boundingBox.y,
                         width = objectInfo.boundingBox.width,
                         height = objectInfo.boundingBox.height,
-                    };
+                    });
                 }
 
                 if (!CaptureOptions.useAsyncReadbackIfSupported && frameCount != Time.frameCount)

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/BoundingBoxLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/BoundingBoxLabeler.cs
@@ -119,7 +119,7 @@ namespace UnityEngine.Perception.GroundTruth
                 for (var i = 0; i < renderedObjectInfos.Length; i++)
                 {
                     var objectInfo = renderedObjectInfos[i];
-                    if (!idLabelConfig.TryGetLabelEntryFromInstanceId(objectInfo.instanceId, out var labelEntry, out var index))
+                    if (!idLabelConfig.TryGetLabelEntryFromInstanceId(objectInfo.instanceId, out var labelEntry))
                         continue;
 
                     m_BoundingBoxValues.Add(new BoundingBoxValue

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/DatasetCaptureTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/DatasetCaptureTests.cs
@@ -897,14 +897,9 @@ namespace GroundTruthTests
             if (escapeGuids)
                 jsonActual = EscapeGuids(jsonActual);
 
-            if (ignoreFormatting)
-            {
-                jsonActual = Regex.Replace(jsonActual, "^\\s*", "", RegexOptions.Multiline);
-                jsonExpected = Regex.Replace(jsonExpected, "^\\s*", "", RegexOptions.Multiline);
-            }
 
-            jsonActual = TestHelper.NormalizeJson(jsonActual);
-            jsonExpected = TestHelper.NormalizeJson(jsonExpected);
+            jsonActual = TestHelper.NormalizeJson(jsonActual, ignoreFormatting);
+            jsonExpected = TestHelper.NormalizeJson(jsonExpected, ignoreFormatting);
 
             Assert.AreEqual(jsonExpected, jsonActual, $"Expected:\n{jsonExpected}\nActual:\n{jsonActual}");
         }

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/PerceptionCameraIntegrationTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/PerceptionCameraIntegrationTests.cs
@@ -27,7 +27,8 @@ namespace GroundTruthTests
             //give the screen a chance to resize
             yield return null;
 
-            var jsonExpected = $@"            {{
+            var jsonExpected = $@"[
+            {{
               ""label_id"": 100,
               ""label_name"": ""label"",
               ""instance_id"": 1,
@@ -35,7 +36,8 @@ namespace GroundTruthTests
               ""y"": {Screen.height / 4:F1},
               ""width"": {Screen.width:F1},
               ""height"": {Screen.height / 2:F1}
-            }}";
+            }}
+          ]";
             var labelingConfiguration = CreateLabelingConfiguration();
             SetupCamera(pc =>
             {

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/PerceptionCameraIntegrationTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/PerceptionCameraIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace GroundTruthTests
     public class PerceptionCameraIntegrationTests : GroundTruthTestBase
     {
         [UnityTest]
-        [UnityPlatform(RuntimePlatform.LinuxPlayer, RuntimePlatform.WindowsPlayer)]
+        [UnityPlatform(RuntimePlatform.LinuxPlayer, RuntimePlatform.WindowsPlayer, RuntimePlatform.LinuxEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.OSXEditor)]
         public IEnumerator EnableBoundingBoxes_GeneratesCorrectDataset()
         {
             //set resolution to ensure we don't have rounding in rendering leading to bounding boxes to change height/width
@@ -46,6 +46,13 @@ namespace GroundTruthTests
             AddTestObjectForCleanup(plane);
             //a plane is 10x10 by default, so scale it down to be 10x1 to cover the center half of the image
             plane.transform.localScale = new Vector3(10f, -1f, .1f);
+            plane.transform.localPosition = new Vector3(0, 0, 10);
+
+            var plane2 = TestHelper.CreateLabeledPlane(label: "nonmatching");
+            AddTestObjectForCleanup(plane2);
+            //place a smaller plane in front to test non-matching objects
+            plane2.transform.localScale = new Vector3(.1f, -1f, .1f);
+            plane2.transform.localPosition = new Vector3(0, 0, 5);
             yield return null;
             DatasetCapture.ResetSimulation();
 

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/PerceptionCameraIntegrationTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/PerceptionCameraIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace GroundTruthTests
     public class PerceptionCameraIntegrationTests : GroundTruthTestBase
     {
         [UnityTest]
-        [UnityPlatform(RuntimePlatform.LinuxPlayer, RuntimePlatform.WindowsPlayer, RuntimePlatform.LinuxEditor, RuntimePlatform.WindowsEditor, RuntimePlatform.OSXEditor)]
+        [UnityPlatform(RuntimePlatform.LinuxPlayer, RuntimePlatform.WindowsPlayer)]
         public IEnumerator EnableBoundingBoxes_GeneratesCorrectDataset()
         {
             //set resolution to ensure we don't have rounding in rendering leading to bounding boxes to change height/width

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/PerceptionCameraIntegrationTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/PerceptionCameraIntegrationTests.cs
@@ -60,7 +60,7 @@ namespace GroundTruthTests
 
             var capturesPath = Path.Combine(DatasetCapture.OutputDirectory, "captures_000.json");
             var capturesJson = File.ReadAllText(capturesPath);
-            StringAssert.Contains(jsonExpected, capturesJson);
+            StringAssert.Contains(TestHelper.NormalizeJson(jsonExpected, true), TestHelper.NormalizeJson(capturesJson, true));
         }
 
         [UnityTest]

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/TestHelper.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/TestHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 using UnityEngine;
 using UnityEngine.Perception.GroundTruth;
 
@@ -28,8 +29,11 @@ namespace GroundTruthTests
         }
 
 #endif
-        public static string NormalizeJson(string json)
+        public static string NormalizeJson(string json, bool normalizeFormatting = false)
         {
+            if (normalizeFormatting)
+                json = Regex.Replace(json, "^\\s*", "", RegexOptions.Multiline);
+
             return json.Replace("\r\n", "\n");
         }
     }


### PR DESCRIPTION
# Peer Review Information:
This fixes a bug where the dataset will include bounding boxes for objects whose labels do not match the label config. These objects were reported as label 0 with a `null` label name.

With this change, these objects are no longer reported.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
Added test for objects whose labels do not match the label config.

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [x] - Updated docs
- [x] - Updated changelog
