### PR TITLE
Feature/lens distortion

### DIFF
--- a/TestProjects/PerceptionHDRP/Assets/Scenes/SampleSceneLensDistortion.unity
+++ b/TestProjects/PerceptionHDRP/Assets/Scenes/SampleSceneLensDistortion.unity
@@ -1,0 +1,984 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 705507994}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &411238276
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 411238281}
+  - component: {fileID: 411238280}
+  - component: {fileID: 411238279}
+  - component: {fileID: 411238278}
+  - component: {fileID: 411238277}
+  - component: {fileID: 411238282}
+  m_Layer: 0
+  m_Name: Crate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &411238277
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b33f0bc2b78db642a758f07826d0dd0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  labels:
+  - Crate
+--- !u!65 &411238278
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &411238279
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &411238280
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &411238281
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 187.1, y: 83.926025, z: -137.7}
+  m_LocalScale: {x: 36.249973, y: 100, z: 36.249973}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &411238282
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 673a227032a8e4940b9828c5b6f852ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  yDegreesPerSecond: 180
+--- !u!1 &464025704
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 464025709}
+  - component: {fileID: 464025708}
+  - component: {fileID: 464025707}
+  - component: {fileID: 464025706}
+  - component: {fileID: 464025705}
+  - component: {fileID: 464025710}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &464025705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b33f0bc2b78db642a758f07826d0dd0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  labels:
+  - Cube
+--- !u!65 &464025706
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &464025707
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &464025708
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &464025709
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 43.9, y: 83.926025, z: -71.3}
+  m_LocalScale: {x: 36.249973, y: 36.249973, z: 36.249973}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &464025710
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 673a227032a8e4940b9828c5b6f852ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  yDegreesPerSecond: 180
+--- !u!1 &705507993
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 705507995}
+  - component: {fileID: 705507994}
+  - component: {fileID: 705507996}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &705507994
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 3.1415927
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 1
+  m_LightShadowCasterMode: 2
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 6.284e-41, z: 0, w: 2.8131285e+20}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &705507995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 96.1856, y: 192.67596, z: -193.83864}
+  m_LocalScale: {x: 36.249973, y: 36.249977, z: 36.249973}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &705507996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a68c43fe1f2a47cfa234b5eeaa98012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 10
+  m_ObsoleteShadowResolutionTier: 1
+  m_ObsoleteUseShadowQualitySettings: 0
+  m_ObsoleteCustomShadowResolution: 512
+  m_ObsoleteContactShadows: 0
+  m_PointlightHDType: 0
+  m_SpotLightShape: 0
+  m_AreaLightShape: 0
+  m_Intensity: 3.1415927
+  m_EnableSpotReflector: 0
+  m_LuxAtDistance: 1
+  m_InnerSpotPercent: 0
+  m_LightDimmer: 1
+  m_VolumetricDimmer: 1
+  m_LightUnit: 2
+  m_FadeDistance: 10000
+  m_AffectDiffuse: 1
+  m_AffectSpecular: 1
+  m_NonLightmappedOnly: 0
+  m_ShapeWidth: 0.5
+  m_ShapeHeight: 0.5
+  m_AspectRatio: 1
+  m_ShapeRadius: 0
+  m_SoftnessScale: 1
+  m_UseCustomSpotLightShadowCone: 0
+  m_CustomSpotLightShadowCone: 30
+  m_MaxSmoothness: 0.99
+  m_ApplyRangeAttenuation: 1
+  m_DisplayAreaLightEmissiveMesh: 0
+  m_AreaLightCookie: {fileID: 0}
+  m_AreaLightShadowCone: 120
+  m_UseScreenSpaceShadows: 0
+  m_InteractsWithSky: 1
+  m_AngularDiameter: 0
+  m_FlareSize: 2
+  m_FlareTint: {r: 1, g: 1, b: 1, a: 1}
+  m_FlareFalloff: 4
+  m_SurfaceTexture: {fileID: 0}
+  m_SurfaceTint: {r: 1, g: 1, b: 1, a: 1}
+  m_Distance: 150000000
+  m_UseRayTracedShadows: 0
+  m_NumRayTracingSamples: 4
+  m_FilterTracedShadow: 1
+  m_FilterSizeTraced: 16
+  m_SunLightConeAngle: 0.5
+  m_LightShadowRadius: 0.5
+  m_SemiTransparentShadow: 0
+  m_ColorShadow: 1
+  m_EvsmExponent: 15
+  m_EvsmLightLeakBias: 0
+  m_EvsmVarianceBias: 0.00001
+  m_EvsmBlurPasses: 0
+  m_LightlayersMask: 1
+  m_LinkShadowLayers: 1
+  m_ShadowNearPlane: 0.1
+  m_BlockerSampleCount: 24
+  m_FilterSampleCount: 16
+  m_MinFilterSize: 0.01
+  m_KernelSize: 5
+  m_LightAngle: 1
+  m_MaxDepthBias: 0.001
+  m_ShadowResolution:
+    m_Override: 512
+    m_UseOverride: 1
+    m_Level: 0
+  m_ShadowDimmer: 1
+  m_VolumetricShadowDimmer: 1
+  m_ShadowFadeDistance: 10000
+  m_UseContactShadow:
+    m_Override: 0
+    m_UseOverride: 1
+    m_Level: 0
+  m_RayTracedContactShadow: 0
+  m_ShadowTint: {r: 0, g: 0, b: 0, a: 1}
+  m_PenumbraTint: 0
+  m_NormalBias: 0.75
+  m_SlopeBias: 0.5
+  m_ShadowUpdateMode: 0
+  m_BarnDoorAngle: 90
+  m_BarnDoorLength: 0.05
+  m_ShadowCascadeRatios:
+  - 0.05
+  - 0.2
+  - 0.3
+  m_ShadowCascadeBorders:
+  - 0.2
+  - 0.2
+  - 0.2
+  - 0.2
+  m_ShadowAlgorithm: 0
+  m_ShadowVariant: 0
+  m_ShadowPrecision: 0
+  useOldInspector: 0
+  useVolumetric: 1
+  featuresFoldout: 1
+  showAdditionalSettings: 0
+  m_AreaLightEmissiveMeshShadowCastingMode: 0
+  m_AreaLightEmissiveMeshMotionVectorGenerationMode: 0
+--- !u!1 &963194225
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 963194228}
+  - component: {fileID: 963194227}
+  - component: {fileID: 963194226}
+  - component: {fileID: 963194229}
+  - component: {fileID: 963194230}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &963194226
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+--- !u!20 &963194227
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 2
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 35, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 12.228561
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 88.91903
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 0
+  m_AllowMSAA: 0
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &963194228
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_LocalRotation: {x: 0, y: -0.3118126, z: 0, w: 0.95014364}
+  m_LocalPosition: {x: 198.01884, y: 87, z: -267.4195}
+  m_LocalScale: {x: 36.249973, y: 36.249973, z: 36.249973}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: -36.337, z: 0}
+--- !u!114 &963194229
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 23c1ce4fb46143f46bc5cb5224c934f6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Version: 7
+  m_ObsoleteRenderingPath: 0
+  m_ObsoleteFrameSettings:
+    overrides: 0
+    enableShadow: 0
+    enableContactShadows: 0
+    enableShadowMask: 0
+    enableSSR: 0
+    enableSSAO: 0
+    enableSubsurfaceScattering: 0
+    enableTransmission: 0
+    enableAtmosphericScattering: 0
+    enableVolumetrics: 0
+    enableReprojectionForVolumetrics: 0
+    enableLightLayers: 0
+    enableExposureControl: 1
+    diffuseGlobalDimmer: 0
+    specularGlobalDimmer: 0
+    shaderLitMode: 0
+    enableDepthPrepassWithDeferredRendering: 0
+    enableTransparentPrepass: 0
+    enableMotionVectors: 0
+    enableObjectMotionVectors: 0
+    enableDecals: 0
+    enableRoughRefraction: 0
+    enableTransparentPostpass: 0
+    enableDistortion: 0
+    enablePostprocess: 0
+    enableOpaqueObjects: 0
+    enableTransparentObjects: 0
+    enableRealtimePlanarReflection: 0
+    enableMSAA: 0
+    enableAsyncCompute: 0
+    runLightListAsync: 0
+    runSSRAsync: 0
+    runSSAOAsync: 0
+    runContactShadowsAsync: 0
+    runVolumeVoxelizationAsync: 0
+    lightLoopSettings:
+      overrides: 0
+      enableDeferredTileAndCluster: 0
+      enableComputeLightEvaluation: 0
+      enableComputeLightVariants: 0
+      enableComputeMaterialVariants: 0
+      enableFptlForForwardOpaque: 0
+      enableBigTilePrepass: 0
+      isFptlEnabled: 0
+  clearColorMode: 0
+  backgroundColorHDR: {r: 0.025, g: 0.07, b: 0.19, a: 0}
+  clearDepth: 1
+  volumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  volumeAnchorOverride: {fileID: 0}
+  antialiasing: 0
+  SMAAQuality: 2
+  dithering: 0
+  stopNaNs: 0
+  taaSharpenStrength: 0.6
+  physicalParameters:
+    m_Iso: 200
+    m_ShutterSpeed: 0.005
+    m_Aperture: 16
+    m_BladeCount: 5
+    m_Curvature: {x: 2, y: 11}
+    m_BarrelClipping: 0.25
+    m_Anamorphism: 0
+  flipYMode: 0
+  fullscreenPassthrough: 0
+  allowDynamicResolution: 0
+  customRenderingSettings: 0
+  invertFaceCulling: 0
+  probeLayerMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  hasPersistentHistory: 0
+  m_RenderingPathCustomFrameSettings:
+    bitDatas:
+      data1: 70280697347933
+      data2: 4539628424926265344
+    lodBias: 1
+    lodBiasMode: 0
+    lodBiasQualityLevel: 0
+    maximumLODLevel: 0
+    maximumLODLevelMode: 0
+    maximumLODLevelQualityLevel: 0
+    materialQuality: 0
+  renderingPathCustomFrameSettingsOverrideMask:
+    mask:
+      data1: 0
+      data2: 0
+  defaultFrameSettings: 0
+--- !u!114 &963194230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4467405dbcbd3d64ab4363e9ae8bb813, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  description: The main camera
+  period: 0.0166
+  startTime: 0
+  captureRgbImages: 1
+  m_Labelers:
+  - id: 0
+  - id: 1
+  - id: 2
+  - id: 3
+  showVisualizations: 1
+  references:
+    version: 1
+    00000000:
+      type: {class: BoundingBox2DLabeler, ns: UnityEngine.Perception.GroundTruth,
+        asm: Unity.Perception.Runtime}
+      data:
+        enabled: 1
+        annotationId: f9f22e05-443f-4602-a422-ebe4ea9b55cb
+        idLabelConfig: {fileID: 11400000, guid: 258de5b48703743468d34fc5bbdfa3aa,
+          type: 2}
+    00000001:
+      type: {class: SemanticSegmentationLabeler, ns: UnityEngine.Perception.GroundTruth,
+        asm: Unity.Perception.Runtime}
+      data:
+        enabled: 1
+        annotationId: 12f94d8d-5425-4deb-9b21-5e53ad957d66
+        labelConfig: {fileID: 11400000, guid: c140c5aa05dd09e4fadaa26de31b1f39, type: 2}
+        m_TargetTextureOverride: {fileID: 0}
+    00000002:
+      type: {class: ObjectCountLabeler, ns: UnityEngine.Perception.GroundTruth, asm: Unity.Perception.Runtime}
+      data:
+        enabled: 1
+        objectCountMetricId: 51da3c27-369d-4929-aea6-d01614635ce2
+        m_LabelConfig: {fileID: 11400000, guid: 258de5b48703743468d34fc5bbdfa3aa,
+          type: 2}
+    00000003:
+      type: {class: RenderedObjectInfoLabeler, ns: UnityEngine.Perception.GroundTruth,
+        asm: Unity.Perception.Runtime}
+      data:
+        enabled: 1
+        objectInfoMetricId: 5ba92024-b3b7-41a7-9d3f-c03a6a8ddd01
+        idLabelConfig: {fileID: 11400000, guid: 258de5b48703743468d34fc5bbdfa3aa,
+          type: 2}
+--- !u!1 &1562495298
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1562495300}
+  - component: {fileID: 1562495299}
+  m_Layer: 0
+  m_Name: Global Volume
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1562495299
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1562495298}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isGlobal: 1
+  priority: 0
+  blendDistance: 0
+  weight: 1
+  sharedProfile: {fileID: 11400000, guid: 6886180e6c51dac4f9ea4d9bcdaa6e13, type: 2}
+--- !u!4 &1562495300
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1562495298}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: 2}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1640252278
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1640252283}
+  - component: {fileID: 1640252282}
+  - component: {fileID: 1640252281}
+  - component: {fileID: 1640252280}
+  - component: {fileID: 1640252279}
+  - component: {fileID: 1640252284}
+  m_Layer: 0
+  m_Name: Box
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1640252279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b33f0bc2b78db642a758f07826d0dd0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  labels:
+  - Box
+--- !u!65 &1640252280
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1640252281
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 73c176f402d2c2f4d929aa5da7585d17, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1640252282
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1640252283
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 65.9, y: 83.926025, z: -212.4}
+  m_LocalScale: {x: 36.249973, y: 100, z: 36.249973}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1640252284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 673a227032a8e4940b9828c5b6f852ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  yDegreesPerSecond: 180

--- a/TestProjects/PerceptionHDRP/Assets/Scenes/SampleSceneLensDistortion.unity.meta
+++ b/TestProjects/PerceptionHDRP/Assets/Scenes/SampleSceneLensDistortion.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 626a1164e53022d4c93345d4666a6713
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/PerceptionHDRP/Assets/Scenes/SampleSceneLensDistortion/Global Volume Profile.asset
+++ b/TestProjects/PerceptionHDRP/Assets/Scenes/SampleSceneLensDistortion/Global Volume Profile.asset
@@ -1,0 +1,53 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7fd9488000d3734a9e00ee676215985, type: 3}
+  m_Name: Global Volume Profile
+  m_EditorClassIdentifier: 
+  components:
+  - {fileID: 3741622219492366159}
+--- !u!114 &3741622219492366159
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9c1bfcd0f0fa7b8468f281d6bbbaf320, type: 3}
+  m_Name: LensDistortion
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  intensity:
+    m_OverrideState: 1
+    m_Value: 0.713
+    min: -1
+    max: 1
+  xMultiplier:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0
+    max: 1
+  yMultiplier:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0
+    max: 1
+  center:
+    m_OverrideState: 0
+    m_Value: {x: 0.5, y: 0.5}
+  scale:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0.01
+    max: 5

--- a/TestProjects/PerceptionHDRP/Assets/Scenes/SampleSceneLensDistortion/Global Volume Profile.asset
+++ b/TestProjects/PerceptionHDRP/Assets/Scenes/SampleSceneLensDistortion/Global Volume Profile.asset
@@ -30,7 +30,7 @@ MonoBehaviour:
   m_AdvancedMode: 0
   intensity:
     m_OverrideState: 1
-    m_Value: 0.713
+    m_Value: 0.805
     min: -1
     max: 1
   xMultiplier:

--- a/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion.meta
+++ b/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fe6387cf00f889a4aa1829716e16631f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion.unity
+++ b/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion.unity
@@ -1,0 +1,791 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 705507994}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &411238276
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 411238281}
+  - component: {fileID: 411238280}
+  - component: {fileID: 411238279}
+  - component: {fileID: 411238278}
+  - component: {fileID: 411238277}
+  - component: {fileID: 411238282}
+  m_Layer: 0
+  m_Name: Crate
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &411238277
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b33f0bc2b78db642a758f07826d0dd0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  labels:
+  - Crate
+--- !u!65 &411238278
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &411238279
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &411238280
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &411238281
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 155.99806, y: 83.926025, z: -149.97618}
+  m_LocalScale: {x: 36.249973, y: 36.249973, z: 36.249973}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &411238282
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 673a227032a8e4940b9828c5b6f852ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  yDegreesPerSecond: 180
+--- !u!1 &464025704
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 464025709}
+  - component: {fileID: 464025708}
+  - component: {fileID: 464025707}
+  - component: {fileID: 464025706}
+  - component: {fileID: 464025705}
+  - component: {fileID: 464025710}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &464025705
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b33f0bc2b78db642a758f07826d0dd0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  labels:
+  - Cube
+--- !u!65 &464025706
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &464025707
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &464025708
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &464025709
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 92.92311, y: 83.926025, z: -136.20119}
+  m_LocalScale: {x: 36.249973, y: 36.249973, z: 36.249973}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &464025710
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 673a227032a8e4940b9828c5b6f852ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  yDegreesPerSecond: 180
+--- !u!1 &705507993
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 705507995}
+  - component: {fileID: 705507994}
+  - component: {fileID: 705507996}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &705507994
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_Enabled: 1
+  serializedVersion: 10
+  m_Type: 1
+  m_Shape: 0
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 3.1415927
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 1
+  m_LightShadowCasterMode: 2
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 4.7e-43, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &705507995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 96.1856, y: 192.67596, z: -193.83864}
+  m_LocalScale: {x: 36.249973, y: 36.249977, z: 36.249973}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!114 &705507996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 705507993}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7a68c43fe1f2a47cfa234b5eeaa98012, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &963194225
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 963194228}
+  - component: {fileID: 963194226}
+  - component: {fileID: 963194230}
+  - component: {fileID: 963194229}
+  - component: {fileID: 963194227}
+  - component: {fileID: 963194231}
+  - component: {fileID: 963194232}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &963194226
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+--- !u!114 &963194227
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_RenderShadows: 1
+  m_RequiresDepthTextureOption: 2
+  m_RequiresOpaqueTextureOption: 2
+  m_CameraType: 0
+  m_Cameras: []
+  m_RendererIndex: -1
+  m_VolumeLayerMask:
+    serializedVersion: 2
+    m_Bits: 1
+  m_VolumeTrigger: {fileID: 0}
+  m_RenderPostProcessing: 0
+  m_Antialiasing: 0
+  m_AntialiasingQuality: 2
+  m_StopNaN: 0
+  m_Dithering: 0
+  m_ClearDepth: 1
+  m_RequiresDepthTexture: 0
+  m_RequiresColorTexture: 0
+  m_Version: 2
+--- !u!4 &963194228
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_LocalRotation: {x: -0.17179534, y: 0.30667058, z: -0.056378223, w: -0.93448436}
+  m_LocalPosition: {x: 198.01884, y: 126.545494, z: -267.4195}
+  m_LocalScale: {x: 36.249973, y: 36.249973, z: 36.249973}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!20 &963194229
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!114 &963194230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4467405dbcbd3d64ab4363e9ae8bb813, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  description: The main camera
+  period: 0.0166
+  startTime: 0
+  captureRgbImages: 1
+  m_Labelers:
+  - id: 0
+  - id: 1
+  - id: 2
+  - id: 3
+  showVisualizations: 1
+  references:
+    version: 1
+    00000000:
+      type: {class: ObjectCountLabeler, ns: UnityEngine.Perception.GroundTruth, asm: Unity.Perception.Runtime}
+      data:
+        enabled: 1
+        objectCountMetricId: 51da3c27-369d-4929-aea6-d01614635ce2
+        m_LabelConfig: {fileID: 11400000, guid: cedcacfb1d9beb34fbbb231166c472fe,
+          type: 2}
+    00000001:
+      type: {class: BoundingBox2DLabeler, ns: UnityEngine.Perception.GroundTruth,
+        asm: Unity.Perception.Runtime}
+      data:
+        enabled: 1
+        annotationId: f9f22e05-443f-4602-a422-ebe4ea9b55cb
+        idLabelConfig: {fileID: 11400000, guid: cedcacfb1d9beb34fbbb231166c472fe,
+          type: 2}
+    00000002:
+      type: {class: RenderedObjectInfoLabeler, ns: UnityEngine.Perception.GroundTruth,
+        asm: Unity.Perception.Runtime}
+      data:
+        enabled: 1
+        objectInfoMetricId: 5ba92024-b3b7-41a7-9d3f-c03a6a8ddd01
+        idLabelConfig: {fileID: 11400000, guid: cedcacfb1d9beb34fbbb231166c472fe,
+          type: 2}
+    00000003:
+      type: {class: SemanticSegmentationLabeler, ns: UnityEngine.Perception.GroundTruth,
+        asm: Unity.Perception.Runtime}
+      data:
+        enabled: 1
+        annotationId: 12f94d8d-5425-4deb-9b21-5e53ad957d66
+        labelConfig: {fileID: 11400000, guid: c140c5aa05dd09e4fadaa26de31b1f39, type: 2}
+        m_TargetTextureOverride: {fileID: 0}
+--- !u!114 &963194231
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7c51d9f2c5784bb4aee3fdf021966e14, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetLight: {fileID: 705507993}
+  target: {fileID: 1640252278}
+--- !u!114 &963194232
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 963194225}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 53f4c974fdf704444959724a41de0cfe, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1640252278
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1640252283}
+  - component: {fileID: 1640252282}
+  - component: {fileID: 1640252279}
+  - component: {fileID: 1640252284}
+  - component: {fileID: 1640252280}
+  m_Layer: 0
+  m_Name: Box1234
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1640252279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8b33f0bc2b78db642a758f07826d0dd0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  labels:
+  - Box
+--- !u!137 &1640252280
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+  m_Bones: []
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 0}
+  m_AABB:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0.5, y: 0.5, z: 0.5}
+  m_DirtyAABB: 0
+--- !u!33 &1640252282
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1640252283
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 96.1856, y: 83.926025, z: -193.83864}
+  m_LocalScale: {x: 36.249973, y: 36.249973, z: 36.249973}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1640252284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1640252278}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 673a227032a8e4940b9828c5b6f852ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  yDegreesPerSecond: 180

--- a/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion.unity
+++ b/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion.unity
@@ -228,7 +228,7 @@ Transform:
   m_LocalScale: {x: 36.249973, y: 36.249973, z: 36.249973}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 0
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &411238282
 MonoBehaviour:
@@ -350,7 +350,7 @@ Transform:
   m_LocalScale: {x: 36.249973, y: 36.249973, z: 36.249973}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &464025710
 MonoBehaviour:
@@ -456,7 +456,7 @@ Transform:
   m_LocalScale: {x: 36.249973, y: 36.249977, z: 36.249973}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
 --- !u!114 &705507996
 MonoBehaviour:
@@ -522,7 +522,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 1
   m_VolumeTrigger: {fileID: 0}
-  m_RenderPostProcessing: 0
+  m_RenderPostProcessing: 1
   m_Antialiasing: 0
   m_AntialiasingQuality: 2
   m_StopNaN: 0
@@ -543,7 +543,7 @@ Transform:
   m_LocalScale: {x: 36.249973, y: 36.249973, z: 36.249973}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!20 &963194229
 Camera:
@@ -609,6 +609,7 @@ MonoBehaviour:
   - id: 1
   - id: 2
   - id: 3
+  m_LensDistortion: {fileID: 0}
   showVisualizations: 1
   references:
     version: 1
@@ -669,6 +670,54 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 53f4c974fdf704444959724a41de0cfe, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1257403327
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1257403328}
+  - component: {fileID: 1257403329}
+  m_Layer: 0
+  m_Name: Global Volume
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1257403328
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257403327}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1257403329
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1257403327}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isGlobal: 1
+  priority: 0
+  blendDistance: 0
+  weight: 1
+  sharedProfile: {fileID: 11400000, guid: 1f38bcef59815b3429d705dd5e490517, type: 2}
 --- !u!1 &1640252278
 GameObject:
   m_ObjectHideFlags: 0
@@ -774,7 +823,7 @@ Transform:
   m_LocalScale: {x: 36.249973, y: 36.249973, z: 36.249973}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1640252284
 MonoBehaviour:

--- a/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion.unity.meta
+++ b/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 158b39ade1e98d54f921da59e9c1197c
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion/Global Volume Profile.asset
+++ b/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion/Global Volume Profile.asset
@@ -12,7 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d7fd9488000d3734a9e00ee676215985, type: 3}
   m_Name: Global Volume Profile
   m_EditorClassIdentifier: 
-  components: []
+  components:
+  - {fileID: 6059181497156826374}
 --- !u!114 &6059181497156826374
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -28,25 +29,25 @@ MonoBehaviour:
   active: 1
   m_AdvancedMode: 0
   intensity:
-    m_OverrideState: 0
-    m_Value: 0
+    m_OverrideState: 1
+    m_Value: 0.715
     min: -1
     max: 1
   xMultiplier:
-    m_OverrideState: 0
+    m_OverrideState: 1
     m_Value: 1
     min: 0
     max: 1
   yMultiplier:
-    m_OverrideState: 0
+    m_OverrideState: 1
     m_Value: 1
     min: 0
     max: 1
   center:
-    m_OverrideState: 0
+    m_OverrideState: 1
     m_Value: {x: 0.5, y: 0.5}
   scale:
-    m_OverrideState: 0
+    m_OverrideState: 1
     m_Value: 1
     min: 0.01
     max: 5

--- a/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion/Global Volume Profile.asset
+++ b/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion/Global Volume Profile.asset
@@ -1,0 +1,52 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d7fd9488000d3734a9e00ee676215985, type: 3}
+  m_Name: Global Volume Profile
+  m_EditorClassIdentifier: 
+  components: []
+--- !u!114 &6059181497156826374
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c5e1dc532bcb41949b58bc4f2abfbb7e, type: 3}
+  m_Name: LensDistortion
+  m_EditorClassIdentifier: 
+  active: 1
+  m_AdvancedMode: 0
+  intensity:
+    m_OverrideState: 0
+    m_Value: 0
+    min: -1
+    max: 1
+  xMultiplier:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0
+    max: 1
+  yMultiplier:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0
+    max: 1
+  center:
+    m_OverrideState: 0
+    m_Value: {x: 0.5, y: 0.5}
+  scale:
+    m_OverrideState: 0
+    m_Value: 1
+    min: 0.01
+    max: 5

--- a/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion/Global Volume Profile.asset.meta
+++ b/TestProjects/PerceptionURP/Assets/Scenes/SampleSceneLensDistortion/Global Volume Profile.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1f38bcef59815b3429d705dd5e490517
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/PerceptionURP/ProjectSettings/ProjectSettings.asset
+++ b/TestProjects/PerceptionURP/ProjectSettings/ProjectSettings.asset
@@ -17,7 +17,7 @@ PlayerSettings:
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}
-  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashScreen: 0
   m_ShowUnitySplashLogo: 1
   m_SplashScreenOverlayOpacity: 1
   m_SplashScreenAnimation: 1
@@ -80,7 +80,7 @@ PlayerSettings:
   bakeCollisionMeshes: 0
   forceSingleInstance: 0
   useFlipModelSwapchain: 1
-  resizableWindow: 0
+  resizableWindow: 1
   useMacAppStoreValidation: 0
   macAppStoreCategory: public.app-category.games
   gpuSkinning: 1
@@ -91,7 +91,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
-  fullscreenMode: 1
+  fullscreenMode: 3
   xboxSpeechDB: 0
   xboxEnableHeadOrientation: 0
   xboxEnableGuest: 0
@@ -111,8 +111,13 @@ PlayerSettings:
   switchNVNShaderPoolsGranularity: 33554432
   switchNVNDefaultPoolsGranularity: 16777216
   switchNVNOtherPoolsGranularity: 16777216
+  switchNVNMaxPublicTextureIDCount: 0
+  switchNVNMaxPublicSamplerIDCount: 0
+  stadiaPresentMode: 0
+  stadiaTargetFramerate: 0
   vulkanNumSwapchainBuffers: 3
   vulkanEnableSetSRGBWrite: 0
+  vulkanEnableLateAcquireNextImage: 0
   m_SupportedAspectRatios:
     4:3: 1
     5:4: 1
@@ -168,7 +173,7 @@ PlayerSettings:
   AndroidMinSdkVersion: 19
   AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
-  aotOptions: 
+  aotOptions: nimt-trampolines=1024
   stripEngineCode: 1
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
@@ -190,22 +195,6 @@ PlayerSettings:
   uIStatusBarHidden: 1
   uIExitOnSuspend: 0
   uIStatusBarStyle: 0
-  iPhoneSplashScreen: {fileID: 0}
-  iPhoneHighResSplashScreen: {fileID: 0}
-  iPhoneTallHighResSplashScreen: {fileID: 0}
-  iPhone47inSplashScreen: {fileID: 0}
-  iPhone55inPortraitSplashScreen: {fileID: 0}
-  iPhone55inLandscapeSplashScreen: {fileID: 0}
-  iPhone58inPortraitSplashScreen: {fileID: 0}
-  iPhone58inLandscapeSplashScreen: {fileID: 0}
-  iPadPortraitSplashScreen: {fileID: 0}
-  iPadHighResPortraitSplashScreen: {fileID: 0}
-  iPadLandscapeSplashScreen: {fileID: 0}
-  iPadHighResLandscapeSplashScreen: {fileID: 0}
-  iPhone65inPortraitSplashScreen: {fileID: 0}
-  iPhone65inLandscapeSplashScreen: {fileID: 0}
-  iPhone61inPortraitSplashScreen: {fileID: 0}
-  iPhone61inLandscapeSplashScreen: {fileID: 0}
   appleTVSplashScreen: {fileID: 0}
   appleTVSplashScreen2x: {fileID: 0}
   tvOSSmallIconLayers: []
@@ -539,6 +528,7 @@ PlayerSettings:
   ps4UseResolutionFallback: 0
   ps4ReprojectionSupport: 0
   ps4UseAudio3dBackend: 0
+  ps4UseLowGarlicFragmentationMode: 1
   ps4SocialScreenEnabled: 0
   ps4ScriptOptimizationLevel: 0
   ps4Audio3dVirtualSpeakerCount: 14
@@ -643,6 +633,7 @@ PlayerSettings:
   XboxOnePersistentLocalStorageSize: 0
   XboxOneXTitleMemory: 8
   XboxOneOverrideIdentityName: 
+  XboxOneOverrideIdentityPublisher: 
   vrEditorSettings:
     daydream:
       daydreamIconForeground: {fileID: 0}

--- a/TestProjects/PerceptionURP/ProjectSettings/QualitySettings.asset
+++ b/TestProjects/PerceptionURP/ProjectSettings/QualitySettings.asset
@@ -95,7 +95,7 @@ QualitySettings:
     skinWeights: 2
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 2
+    antiAliasing: 0
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -37,6 +37,8 @@ Fixed colors in semantic segmentation images being darker than those specified i
 
 Fixed objects being incorrectly labeled when they do not match any entries in the label config
 
+Fixed lens distortion in URP and HDRP now being applied to ground truth
+
 ### Security
 
 ## [0.3.0-preview.1] - 2020-08-07

--- a/com.unity.perception/Runtime/GroundTruth/GroundTruthCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/GroundTruthCrossPipelinePass.cs
@@ -6,7 +6,7 @@ using UnityEngine.Rendering;
 
 namespace UnityEngine.Perception.GroundTruth
 {
-    public abstract class GroundTruthCrossPipelinePass : IGroundTruthGenerator
+    internal abstract class GroundTruthCrossPipelinePass : IGroundTruthGenerator
     {
         public Camera targetCamera;
 

--- a/com.unity.perception/Runtime/GroundTruth/GroundTruthCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/GroundTruthCrossPipelinePass.cs
@@ -6,7 +6,7 @@ using UnityEngine.Rendering;
 
 namespace UnityEngine.Perception.GroundTruth
 {
-    abstract class GroundTruthCrossPipelinePass : IGroundTruthGenerator
+    public abstract class GroundTruthCrossPipelinePass : IGroundTruthGenerator
     {
         public Camera targetCamera;
 

--- a/com.unity.perception/Runtime/GroundTruth/GroundTruthRendererFeature.cs
+++ b/com.unity.perception/Runtime/GroundTruth/GroundTruthRendererFeature.cs
@@ -33,7 +33,7 @@ namespace UnityEngine.Perception.GroundTruth
 
     class SemanticSegmentationUrpPass : ScriptableRenderPass
     {
-        SemanticSegmentationCrossPipelinePass m_SemanticSegmentationCrossPipelinePass;
+        public SemanticSegmentationCrossPipelinePass m_SemanticSegmentationCrossPipelinePass;
 
         public SemanticSegmentationUrpPass(Camera camera, RenderTexture targetTexture, SemanticSegmentationLabelConfig labelConfig)
         {
@@ -57,7 +57,7 @@ namespace UnityEngine.Perception.GroundTruth
 
     class LensDistortionUrpPass : ScriptableRenderPass
     {
-        LensDistortionCrossPipelinePass m_LensDistortionCrossPipelinePass;
+        public LensDistortionCrossPipelinePass m_LensDistortionCrossPipelinePass;
 
         public LensDistortionUrpPass(Camera camera, RenderTexture targetTexture)
         {

--- a/com.unity.perception/Runtime/GroundTruth/GroundTruthRendererFeature.cs
+++ b/com.unity.perception/Runtime/GroundTruth/GroundTruthRendererFeature.cs
@@ -55,6 +55,30 @@ namespace UnityEngine.Perception.GroundTruth
         }
     }
 
+    class LensDistortionUrpPass : ScriptableRenderPass
+    {
+        LensDistortionCrossPipelinePass m_LensDistortionCrossPipelinePass;
+
+        public LensDistortionUrpPass(Camera camera, RenderTexture targetTexture)
+        {
+            m_LensDistortionCrossPipelinePass = new LensDistortionCrossPipelinePass(camera, targetTexture);
+            ConfigureTarget(targetTexture, targetTexture.depthBuffer);
+            m_LensDistortionCrossPipelinePass.Setup();
+        }
+
+        public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
+        {
+            var commandBuffer = CommandBufferPool.Get(nameof(SemanticSegmentationUrpPass));
+            m_LensDistortionCrossPipelinePass.Execute(context, commandBuffer, renderingData.cameraData.camera, renderingData.cullResults);
+            CommandBufferPool.Release(commandBuffer);
+        }
+
+        public void Cleanup()
+        {
+            m_LensDistortionCrossPipelinePass.Cleanup();
+        }
+    }
+
     public class GroundTruthRendererFeature : ScriptableRendererFeature
     {
         public override void Create() {}

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
@@ -78,6 +78,7 @@ namespace UnityEngine.Perception.GroundTruth
 
 #if HDRP_PRESENT
         SemanticSegmentationPass m_SemanticSegmentationPass;
+        private LensDistortionPass m_LensDistortionPass;
 #endif
 
         Dictionary<int, AsyncAnnotation> m_AsyncAnnotations;
@@ -172,6 +173,12 @@ namespace UnityEngine.Perception.GroundTruth
                 name = "Labeling Pass"
             };
             customPassVolume.customPasses.Add(m_SemanticSegmentationPass);
+
+            m_LensDistortionPass = new LensDistortionPass(myCamera, targetTexture)
+            {
+                name = "Lens Distortion Pass"
+            };
+            customPassVolume.customPasses.Add(m_LensDistortionPass);
 #endif
 #if URP_PRESENT
             perceptionCamera.AddScriptableRenderPass(new SemanticSegmentationUrpPass(myCamera, targetTexture, labelConfig));

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
@@ -180,9 +180,11 @@ namespace UnityEngine.Perception.GroundTruth
                 name = "Lens Distortion Pass"
             };
             customPassVolume.customPasses.Add(m_LensDistortionPass);
-#endif
-#if URP_PRESENT
+#elif URP_PRESENT
             perceptionCamera.AddScriptableRenderPass(new SemanticSegmentationUrpPass(myCamera, targetTexture, labelConfig));
+
+            // Lens Distortion
+            perceptionCamera.AddScriptableRenderPass(new LensDistortionUrpPass(myCamera, targetTexture));
 #endif
 
             var specs = labelConfig.labelEntries.Select((l) => new SemanticSegmentationSpec()

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
@@ -77,13 +77,17 @@ namespace UnityEngine.Perception.GroundTruth
         AnnotationDefinition m_SemanticSegmentationAnnotationDefinition;
         RenderTextureReader<Color32> m_SemanticSegmentationTextureReader;
 
-#if HDRP_PRESENT
-    SemanticSegmentationPass m_SemanticSegmentationPass;
-    LensDistortionPass m_LensDistortionPass;
-#elif URP_PRESENT
-    SemanticSegmentationUrpPass m_SemanticSegmentationPass;
-    LensDistortionUrpPass m_LensDistortionPass;
-#endif
+    #if HDRP_PRESENT
+        SemanticSegmentationPass m_SemanticSegmentationPass;
+        LensDistortionPass m_LensDistortionPass;
+        internal readonly bool m_fLensDistortionEnabled = true;
+    #elif URP_PRESENT
+        SemanticSegmentationUrpPass m_SemanticSegmentationPass;
+        LensDistortionUrpPass m_LensDistortionPass;
+        internal readonly bool m_fLensDistortionEnabled = true;
+    #else
+        internal readonly bool m_fLensDistortionEnabled = false;
+    #endif
 
         Dictionary<int, AsyncAnnotation> m_AsyncAnnotations;
 
@@ -178,19 +182,24 @@ namespace UnityEngine.Perception.GroundTruth
             };
             customPassVolume.customPasses.Add(m_SemanticSegmentationPass);
 
-            m_LensDistortionPass = new LensDistortionPass(myCamera, targetTexture)
+            if (m_fLensDistortionEnabled)
             {
-                name = "Lens Distortion Pass"
-            };
-            customPassVolume.customPasses.Add(m_LensDistortionPass);
+                m_LensDistortionPass = new LensDistortionPass(myCamera, targetTexture)
+                {
+                    name = "Lens Distortion Pass"
+                };
+                customPassVolume.customPasses.Add(m_LensDistortionPass);
+            }
 #elif URP_PRESENT
             // Semantic Segmentation
             m_SemanticSegmentationPass = new SemanticSegmentationUrpPass(myCamera, targetTexture, labelConfig);
             perceptionCamera.AddScriptableRenderPass(m_SemanticSegmentationPass);
 
             // Lens Distortion
-            m_LensDistortionPass = new LensDistortionUrpPass(myCamera, targetTexture);
-            perceptionCamera.AddScriptableRenderPass(m_LensDistortionPass);
+            if(m_fLensDistortionEnabled) {
+                m_LensDistortionPass = new LensDistortionUrpPass(myCamera, targetTexture);
+                perceptionCamera.AddScriptableRenderPass(m_LensDistortionPass);
+            }
 #endif
 
             var specs = labelConfig.labelEntries.Select((l) => new SemanticSegmentationSpec()

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
@@ -77,16 +77,14 @@ namespace UnityEngine.Perception.GroundTruth
         AnnotationDefinition m_SemanticSegmentationAnnotationDefinition;
         RenderTextureReader<Color32> m_SemanticSegmentationTextureReader;
 
+        internal bool m_fLensDistortionEnabled = false;
+
     #if HDRP_PRESENT
         SemanticSegmentationPass m_SemanticSegmentationPass;
         LensDistortionPass m_LensDistortionPass;
-        internal readonly bool m_fLensDistortionEnabled = true;
     #elif URP_PRESENT
         SemanticSegmentationUrpPass m_SemanticSegmentationPass;
         LensDistortionUrpPass m_LensDistortionPass;
-        internal readonly bool m_fLensDistortionEnabled = true;
-    #else
-        internal readonly bool m_fLensDistortionEnabled = false;
     #endif
 
         Dictionary<int, AsyncAnnotation> m_AsyncAnnotations;
@@ -182,24 +180,24 @@ namespace UnityEngine.Perception.GroundTruth
             };
             customPassVolume.customPasses.Add(m_SemanticSegmentationPass);
 
-            if (m_fLensDistortionEnabled)
+            m_LensDistortionPass = new LensDistortionPass(myCamera, targetTexture)
             {
-                m_LensDistortionPass = new LensDistortionPass(myCamera, targetTexture)
-                {
-                    name = "Lens Distortion Pass"
-                };
-                customPassVolume.customPasses.Add(m_LensDistortionPass);
-            }
+                name = "Lens Distortion Pass"
+            };
+            customPassVolume.customPasses.Add(m_LensDistortionPass);
+
+            m_fLensDistortionEnabled = true;
 #elif URP_PRESENT
             // Semantic Segmentation
             m_SemanticSegmentationPass = new SemanticSegmentationUrpPass(myCamera, targetTexture, labelConfig);
             perceptionCamera.AddScriptableRenderPass(m_SemanticSegmentationPass);
 
             // Lens Distortion
-            if(m_fLensDistortionEnabled) {
-                m_LensDistortionPass = new LensDistortionUrpPass(myCamera, targetTexture);
-                perceptionCamera.AddScriptableRenderPass(m_LensDistortionPass);
-            }
+
+            m_LensDistortionPass = new LensDistortionUrpPass(myCamera, targetTexture);
+            perceptionCamera.AddScriptableRenderPass(m_LensDistortionPass);
+
+            m_fLensDistortionEnabled = true;
 #endif
 
             var specs = labelConfig.labelEntries.Select((l) => new SemanticSegmentationSpec()

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
@@ -8,6 +8,7 @@ using Unity.Collections;
 using Unity.Simulation;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Profiling;
+using UnityEngine.Rendering;
 using UnityEngine.UI;
 
 #if HDRP_PRESENT

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
@@ -78,8 +78,11 @@ namespace UnityEngine.Perception.GroundTruth
         RenderTextureReader<Color32> m_SemanticSegmentationTextureReader;
 
 #if HDRP_PRESENT
-        SemanticSegmentationPass m_SemanticSegmentationPass;
-        private LensDistortionPass m_LensDistortionPass;
+    SemanticSegmentationPass m_SemanticSegmentationPass;
+    LensDistortionPass m_LensDistortionPass;
+#elif URP_PRESENT
+    SemanticSegmentationUrpPass m_SemanticSegmentationPass;
+    LensDistortionUrpPass m_LensDistortionPass;
 #endif
 
         Dictionary<int, AsyncAnnotation> m_AsyncAnnotations;
@@ -181,10 +184,13 @@ namespace UnityEngine.Perception.GroundTruth
             };
             customPassVolume.customPasses.Add(m_LensDistortionPass);
 #elif URP_PRESENT
-            perceptionCamera.AddScriptableRenderPass(new SemanticSegmentationUrpPass(myCamera, targetTexture, labelConfig));
+            // Semantic Segmentation
+            m_SemanticSegmentationPass = new SemanticSegmentationUrpPass(myCamera, targetTexture, labelConfig);
+            perceptionCamera.AddScriptableRenderPass(m_SemanticSegmentationPass);
 
             // Lens Distortion
-            perceptionCamera.AddScriptableRenderPass(new LensDistortionUrpPass(myCamera, targetTexture));
+            m_LensDistortionPass = new LensDistortionUrpPass(myCamera, targetTexture);
+            perceptionCamera.AddScriptableRenderPass(m_LensDistortionPass);
 #endif
 
             var specs = labelConfig.labelEntries.Select((l) => new SemanticSegmentationSpec()

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
@@ -12,7 +12,7 @@ namespace UnityEngine.Perception.GroundTruth
     {
         const string k_ShaderName = "Perception/LensDistortion";
 
-        static int s_LastFrameExecuted = -1;
+        //static int s_LastFrameExecuted = -1;
 
         //Serialize the shader so that the shader asset is included in player builds when the SemanticSegmentationPass is used.
         //Currently commented out and shaders moved to Resources folder due to serialization crashes when it is enabled.
@@ -54,15 +54,16 @@ namespace UnityEngine.Perception.GroundTruth
 
                 m_distortedTexture = new RenderTexture(Screen.width, Screen.height, 0, RenderTextureFormat.ARGBFloat, RenderTextureReadWrite.Linear);
                 m_distortedTexture.enableRandomWrite = true;
+                m_distortedTexture.filterMode = FilterMode.Point;
                 m_distortedTexture.Create();
             }
         }
 
         protected override void ExecutePass(ScriptableRenderContext renderContext, CommandBuffer cmd, Camera camera, CullingResults cullingResult)
         {
-            if (s_LastFrameExecuted == Time.frameCount)
-                Debug.LogError("Lens Distortion executed twice in the same frame, this may lead to undesirable results.");
-            s_LastFrameExecuted = Time.frameCount;
+            //if (s_LastFrameExecuted == Time.frameCount)
+            //    Debug.LogError("Lens Distortion executed twice in the same frame, this may lead to undesirable results.");
+            //s_LastFrameExecuted = Time.frameCount;
 
             // Blitmayhem
             cmd.Blit(m_TargetTexture, m_distortedTexture, m_LensDistortionMaterial);

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
@@ -70,6 +70,8 @@ namespace UnityEngine.Perception.GroundTruth
 
         protected override void ExecutePass(ScriptableRenderContext renderContext, CommandBuffer cmd, Camera camera, CullingResults cullingResult)
         {
+            // Review: This has been removed since we may apply this pass to various stages, just want to confirm I'm
+            // not missing anything before removing it
             //if (s_LastFrameExecuted == Time.frameCount)
             //    Debug.LogError("Lens Distortion executed twice in the same frame, this may lead to undesirable results.");
             //s_LastFrameExecuted = Time.frameCount;
@@ -85,21 +87,16 @@ namespace UnityEngine.Perception.GroundTruth
 
         public override void SetupMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId)
         {
-            // Grab the Lens Distortion from Perception Camera (collected in OnBeginCameraRendering
-            //PerceptionCamera perceptionCamera = this.targetCamera.GetComponent<PerceptionCamera>();
-            //if(perceptionCamera != null)
-            //{
-            //    m_LensDistortion = perceptionCamera.m_LensDistortion;
-            //}
+            // Grab the Lens Distortion from Perception Camera stack
+            var hdCamera = HDCamera.GetOrCreate(targetCamera);
+            var stack = hdCamera.volumeStack;
+            var lensDistortion = stack.GetComponent<LensDistortion>();
+            Debug.Log("lens distortion intensity: " + lensDistortion.intensity.value);
 
             // This code is lifted from the SetupLensDistortion() function in
             // https://github.com/Unity-Technologies/Graphics/blob/257b08bba6c11de0f894e42e811124247a522d3c/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
             // This is in UnityEngine.Rendering.Universal.Internal.PostProcessPass::SetupLensDistortion so it's
             // unclear how to re-use this code
-
-            var stack = VolumeManager.instance.stack;
-            var lensDistortion = stack.GetComponent<LensDistortion>();
-            //Debug.Log("lens distortion intensity: " + lensDistortion.intensity.value);
 
             float amount = 1.6f * Mathf.Max(Mathf.Abs(lensDistortion.intensity.value * 100.0f), 1.0f);
             float theta = Mathf.Deg2Rad * Mathf.Min(160f, amount);

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
@@ -8,64 +8,75 @@ namespace UnityEngine.Perception.GroundTruth
     /// Custom Pass which renders labeled images where each object labeled with a Labeling component is drawn with the
     /// value specified by the given LabelingConfiguration.
     /// </summary>
-    class SemanticSegmentationCrossPipelinePass : GroundTruthCrossPipelinePass
+    class LensDistortionCrossPipelinePass : GroundTruthCrossPipelinePass
     {
-        const string k_ShaderName = "Perception/SemanticSegmentation";
-        static readonly int k_LabelingId = Shader.PropertyToID("LabelingId");
+        const string k_ShaderName = "Perception/LensDistortion";
 
         static int s_LastFrameExecuted = -1;
-
-        SemanticSegmentationLabelConfig m_LabelConfig;
 
         //Serialize the shader so that the shader asset is included in player builds when the SemanticSegmentationPass is used.
         //Currently commented out and shaders moved to Resources folder due to serialization crashes when it is enabled.
         //See https://fogbugz.unity3d.com/f/cases/1187378/
         //[SerializeField]
-        Shader m_ClassLabelingShader;
-        Material m_OverrideMaterial;
 
-        public SemanticSegmentationCrossPipelinePass(Camera targetCamera, SemanticSegmentationLabelConfig labelConfig) : base(targetCamera)
+        private Shader m_LensDistortionShader;
+        private Material m_LensDistortionMaterial;
+
+        public RenderTexture m_TargetTexture;
+        private RenderTexture m_distortedTexture;
+
+        public LensDistortionCrossPipelinePass(Camera targetCamera, RenderTexture targetTexture)
+            : base(targetCamera)
         {
-            this.m_LabelConfig = labelConfig;
+            m_TargetTexture = targetTexture;
         }
 
         public override void Setup()
         {
             base.Setup();
-            m_ClassLabelingShader = Shader.Find(k_ShaderName);
+            m_LensDistortionShader = Shader.Find(k_ShaderName);
 
             var shaderVariantCollection = new ShaderVariantCollection();
 
             if (shaderVariantCollection != null)
-            {
-                shaderVariantCollection.Add(new ShaderVariantCollection.ShaderVariant(m_ClassLabelingShader, PassType.ScriptableRenderPipeline));
-            }
+                shaderVariantCollection.Add(new ShaderVariantCollection.ShaderVariant(m_LensDistortionShader, PassType.ScriptableRenderPipeline));
 
-            m_OverrideMaterial = new Material(m_ClassLabelingShader);
+            m_LensDistortionMaterial = new Material(m_LensDistortionShader);
 
-            if (shaderVariantCollection != null)
-            {
+            if(shaderVariantCollection != null)
                 shaderVariantCollection.WarmUp();
+
+            // Set up a new texture
+            if (m_distortedTexture == null || m_distortedTexture.width != Screen.width || m_distortedTexture.height != Screen.height) {
+
+                if (m_distortedTexture != null)
+                    m_distortedTexture.Release();
+
+                m_distortedTexture = new RenderTexture(Screen.width, Screen.height, 0, RenderTextureFormat.ARGBFloat, RenderTextureReadWrite.Linear);
+                m_distortedTexture.enableRandomWrite = true;
+                m_distortedTexture.Create();
             }
         }
 
         protected override void ExecutePass(ScriptableRenderContext renderContext, CommandBuffer cmd, Camera camera, CullingResults cullingResult)
         {
             if (s_LastFrameExecuted == Time.frameCount)
-            {
-                Debug.LogError("Semantic segmentation was run twice in the same frame. Multiple semantic segmentations are not currently supported.");
-            }
-
+                Debug.LogError("Lens Distortion executed twice in the same frame, this may lead to undesirable results.");
             s_LastFrameExecuted = Time.frameCount;
-            var renderList = CreateRendererListDesc(camera, cullingResult, "FirstPass", 0, m_OverrideMaterial, -1);
-            cmd.ClearRenderTarget(true, true, Color.black);
-            DrawRendererList(renderContext, cmd, RendererList.Create(renderList));
+
+            // Blitmayhem
+            cmd.Blit(m_TargetTexture, m_distortedTexture, m_LensDistortionMaterial);
+            cmd.Blit(m_distortedTexture, m_TargetTexture);
         }
 
         public override void SetupMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId)
         {
+            // Note: Problably don't need this
+
+            /*
             var entry = new SemanticSegmentationLabelEntry();
             bool found = false;
+
             foreach (var l in m_LabelConfig.labelEntries)
             {
                 if (labeling.labels.Contains(l.label))
@@ -79,6 +90,7 @@ namespace UnityEngine.Perception.GroundTruth
             //Set the labeling ID so that it can be accessed in ClassSemanticSegmentationPass.shader
             if (found)
                 mpb.SetVector(k_LabelingId, entry.color);
+            */
         }
     }
 }

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
@@ -124,11 +124,18 @@ namespace UnityEngine.Perception.GroundTruth
             var center = new Vector2(0.0f, 0.0f);
             var mult = new Vector2(1.0f, 1.0f);
 
+            bool fRenderPostProcessingEnabled = false;
+        #if HDRP_PRESENT
+            fRenderPostProcessingEnabled = m_lensDistortion != null;    // This is redundant, but for path completeness
+        #elif URP_PRESENT
+            fRenderPostProcessingEnabled = targetCamera.GetUniversalAdditionalCameraData().renderPostProcessing;
+        #endif
+
             if (lensDistortionOverride.HasValue)
             {
                 intensity = lensDistortionOverride.Value;
             }
-            else if (m_lensDistortion != null && targetCamera.GetUniversalAdditionalCameraData().renderPostProcessing == true)
+            else if (m_lensDistortion != null && fRenderPostProcessingEnabled == true)
             {
                 // This is a bit finicky for URP - since Lens Distortion comes off the VolumeManager stack as active
                 // even if post processing is not enabled.  An intensity of 0.0f is untenable, so the below checks

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
@@ -123,21 +123,24 @@ namespace UnityEngine.Perception.GroundTruth
             var center = new Vector2(0.0f, 0.0f);
             var mult = new Vector2(1.0f, 1.0f);
 
-            bool fRenderPostProcessingEnabled = false;
-
         #if HDRP_PRESENT
-            fRenderPostProcessingEnabled = m_lensDistortion != null;    // This is redundant, but for path completeness
+            if(m_lensDistortion == null)
+                return false;
         #elif URP_PRESENT
-            if(targetCamera != null) {
-                fRenderPostProcessingEnabled = targetCamera.GetUniversalAdditionalCameraData().renderPostProcessing;
-            }
+            if(targetCamera == null)
+                return false;
+
+            if(targetCamera.GetUniversalAdditionalCameraData().renderPostProcessing == false && lensDistortionOverride.HasValue == false)
+                return false;
+        #else
+            return false;
         #endif
 
             if (lensDistortionOverride.HasValue)
             {
                 intensity = lensDistortionOverride.Value;
             }
-            else if (m_lensDistortion != null && fRenderPostProcessingEnabled == true)
+            else if (m_lensDistortion != null)
             {
                 // This is a bit finicky for URP - since Lens Distortion comes off the VolumeManager stack as active
                 // even if post processing is not enabled.  An intensity of 0.0f is untenable, so the below checks
@@ -150,10 +153,6 @@ namespace UnityEngine.Perception.GroundTruth
                     mult.y = Mathf.Max(m_lensDistortion.yMultiplier.value, 1e-4f);
                     scale = 1.0f / m_lensDistortion.scale.value;
                 }
-            }
-            else
-            {
-                return false;
             }
 
             float amount = 1.6f * Mathf.Max(Mathf.Abs(intensity * 100.0f), 1.0f);

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Unity.Mathematics;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
@@ -14,7 +15,7 @@ namespace UnityEngine.Perception.GroundTruth
     /// Custom Pass which renders labeled images where each object labeled with a Labeling component is drawn with the
     /// value specified by the given LabelingConfiguration.
     /// </summary>
-    class LensDistortionCrossPipelinePass : GroundTruthCrossPipelinePass
+    public class LensDistortionCrossPipelinePass : GroundTruthCrossPipelinePass
     {
         const string k_ShaderName = "Perception/LensDistortion";
 
@@ -29,8 +30,13 @@ namespace UnityEngine.Perception.GroundTruth
         private Shader m_LensDistortionShader;
         private Material m_LensDistortionMaterial;
 
+        private bool fInitialized = false;
+
         public static readonly int _Distortion_Params1 = Shader.PropertyToID("_Distortion_Params1");
         public static readonly int _Distortion_Params2 = Shader.PropertyToID("_Distortion_Params2");
+
+        public LensDistortion m_lensDistortion;
+        public float? lensDistortionOverride = null;        // Largely for testing, but could be useful otherwise
 
         public RenderTexture m_TargetTexture;
         private RenderTexture m_distortedTexture;
@@ -70,6 +76,19 @@ namespace UnityEngine.Perception.GroundTruth
                 m_distortedTexture.filterMode = FilterMode.Point;
                 m_distortedTexture.Create();
             }
+
+            // Grab the lens distortion
+#if HDRP_PRESENT
+            // Grab the Lens Distortion from Perception Camera stack
+            var hdCamera = HDCamera.GetOrCreate(targetCamera);
+            var stack = hdCamera.volumeStack;
+            m_lensDistortion = stack.GetComponent<LensDistortion>();
+#else
+            var stack = VolumeManager.instance.stack;
+            m_lensDistortion = stack.GetComponent<LensDistortion>();
+#endif
+
+            fInitialized = true;
         }
 
         protected override void ExecutePass(ScriptableRenderContext renderContext, CommandBuffer cmd, Camera camera, CullingResults cullingResult)
@@ -80,11 +99,9 @@ namespace UnityEngine.Perception.GroundTruth
             //    Debug.LogError("Lens Distortion executed twice in the same frame, this may lead to undesirable results.");
             //s_LastFrameExecuted = Time.frameCount;
 
-            var stack = VolumeManager.instance.stack;
-            var lensDistortion = stack.GetComponent<LensDistortion>();
-            //Debug.Log("lens distortion intensity: " + lensDistortion.intensity.value);
+            SetLensDistortionShaderParameters();
 
-            // Blitmayhem
+                // Blitmayhem
             cmd.Blit(m_TargetTexture, m_distortedTexture, m_LensDistortionMaterial);
             cmd.Blit(m_distortedTexture, m_TargetTexture);
 
@@ -92,47 +109,60 @@ namespace UnityEngine.Perception.GroundTruth
             cmd.Clear();
         }
 
-        public override void SetupMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId)
+        public void SetLensDistortionShaderParameters()
         {
-
-#if HDRP_PRESENT
-            // Grab the Lens Distortion from Perception Camera stack
-            var hdCamera = HDCamera.GetOrCreate(targetCamera);
-            var stack = hdCamera.volumeStack;
-            var lensDistortion = stack.GetComponent<LensDistortion>();
-#else
-            var stack = VolumeManager.instance.stack;
-            var lensDistortion = stack.GetComponent<LensDistortion>();
-            Debug.Log("lens distortion intensity: " + lensDistortion.intensity.value);
-#endif
+            if (fInitialized == false)
+                return;
 
             // This code is lifted from the SetupLensDistortion() function in
             // https://github.com/Unity-Technologies/Graphics/blob/257b08bba6c11de0f894e42e811124247a522d3c/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
             // This is in UnityEngine.Rendering.Universal.Internal.PostProcessPass::SetupLensDistortion so it's
             // unclear how to re-use this code
 
-            float amount = 1.6f * Mathf.Max(Mathf.Abs(lensDistortion.intensity.value * 100.0f), 1.0f);
+            float intensity = 0.5f;
+            float scale = 1.0f;
+            var center = new Vector2(0.0f, 0.0f);
+            var mult = new Vector2(1.0f, 1.0f);
+
+            if (lensDistortionOverride.HasValue)
+            {
+                intensity = lensDistortionOverride.Value;
+            }
+            else if (m_lensDistortion != null)
+            {
+                intensity = m_lensDistortion.intensity.value;
+                center = m_lensDistortion.center.value * 2f - Vector2.one;
+                mult.x = Mathf.Max(m_lensDistortion.xMultiplier.value, 1e-4f);
+                mult.y = Mathf.Max(m_lensDistortion.yMultiplier.value, 1e-4f);
+                scale = 1.0f / m_lensDistortion.scale.value;
+            }
+
+            float amount = 1.6f * Mathf.Max(Mathf.Abs(intensity * 100.0f), 1.0f);
             float theta = Mathf.Deg2Rad * Mathf.Min(160f, amount);
             float sigma = 2.0f * Mathf.Tan(theta * 0.5f);
-            var center = lensDistortion.center.value * 2f - Vector2.one;
+
             var p1 = new Vector4(
                 center.x,
                 center.y,
-                Mathf.Max(lensDistortion.xMultiplier.value, 1e-4f),
-                Mathf.Max(lensDistortion.yMultiplier.value, 1e-4f)
+                mult.x,
+                mult.y
             );
 
             var p2 = new Vector4(
-                lensDistortion.intensity.value >= 0f ? theta : 1f / theta,
+                intensity >= 0f ? theta : 1f / theta,
                 sigma,
-                1.0f / lensDistortion.scale.value,
-                lensDistortion.intensity.value * 100.0f
+                scale,
+                intensity * 100.0f
             );
 
             // Set Shader Constants
             m_LensDistortionMaterial.SetVector(_Distortion_Params1, p1);
             m_LensDistortionMaterial.SetVector(_Distortion_Params2, p2);
+        }
 
+        public override void SetupMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId)
+        {
+            SetLensDistortionShaderParameters();
         }
     }
 }

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
@@ -9,6 +9,8 @@ using UnityEngine.Rendering;
     using UnityEngine.Rendering.Universal;
 #endif
 
+#if HDRP_PRESENT || URP_PRESENT
+
 namespace UnityEngine.Perception.GroundTruth
 {
     /// <summary>
@@ -173,3 +175,5 @@ namespace UnityEngine.Perception.GroundTruth
         }
     }
 }
+
+#endif // ! HDRP_PRESENT || URP_PRESENT

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
@@ -2,7 +2,11 @@
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.Rendering;
 
-using UnityEngine.Rendering.HighDefinition;
+#if HDRP_PRESENT
+    using UnityEngine.Rendering.HighDefinition;
+#else
+    using UnityEngine.Rendering.Universal;
+#endif
 
 namespace UnityEngine.Perception.GroundTruth
 {
@@ -78,20 +82,29 @@ namespace UnityEngine.Perception.GroundTruth
 
             var stack = VolumeManager.instance.stack;
             var lensDistortion = stack.GetComponent<LensDistortion>();
-            Debug.Log("lens distortion intensity: " + lensDistortion.intensity.value);
+            //Debug.Log("lens distortion intensity: " + lensDistortion.intensity.value);
 
             // Blitmayhem
             cmd.Blit(m_TargetTexture, m_distortedTexture, m_LensDistortionMaterial);
             cmd.Blit(m_distortedTexture, m_TargetTexture);
+
+            renderContext.ExecuteCommandBuffer(cmd);
+            cmd.Clear();
         }
 
         public override void SetupMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId)
         {
+
+#if HDRP_PRESENT
             // Grab the Lens Distortion from Perception Camera stack
             var hdCamera = HDCamera.GetOrCreate(targetCamera);
             var stack = hdCamera.volumeStack;
             var lensDistortion = stack.GetComponent<LensDistortion>();
+#else
+            var stack = VolumeManager.instance.stack;
+            var lensDistortion = stack.GetComponent<LensDistortion>();
             Debug.Log("lens distortion intensity: " + lensDistortion.intensity.value);
+#endif
 
             // This code is lifted from the SetupLensDistortion() function in
             // https://github.com/Unity-Technologies/Graphics/blob/257b08bba6c11de0f894e42e811124247a522d3c/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
@@ -124,7 +124,9 @@ namespace UnityEngine.Perception.GroundTruth
         #if HDRP_PRESENT
             fRenderPostProcessingEnabled = m_lensDistortion != null;    // This is redundant, but for path completeness
         #elif URP_PRESENT
-            fRenderPostProcessingEnabled = targetCamera.GetUniversalAdditionalCameraData().renderPostProcessing;
+            if(targetCamera != null) {
+                fRenderPostProcessingEnabled = targetCamera.GetUniversalAdditionalCameraData().renderPostProcessing;
+            }
         #endif
 
             if (lensDistortionOverride.HasValue)

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs.meta
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ad37b813e25c450fbc65b2820a7d9dc2
+timeCreated: 1598041907

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionPass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionPass.cs
@@ -1,0 +1,54 @@
+#if HDRP_PRESENT
+
+using System;
+using UnityEngine.Rendering;
+using UnityEngine.Rendering.HighDefinition;
+
+namespace UnityEngine.Perception.GroundTruth
+{
+    /// <summary>
+    /// Custom Pass which renders labeled images where each object with a Labeling component is drawn with the value
+    /// specified by the given LabelingConfiguration.
+    /// </summary>
+    public class LensDistortionPass : CustomPass
+    {
+        public RenderTexture targetTexture;
+        public Camera targetCamera;
+
+        LensDistortionCrossPipelinePass m_LensDistortionCrossPipelinePass;
+
+        public LensDistortionPass(Camera targetCamera, RenderTexture targetTexture)
+        {
+            this.targetTexture = targetTexture;
+            this.targetCamera = targetCamera;
+            EnsureInit();
+        }
+
+        void EnsureInit()
+        {
+            if (m_LensDistortionCrossPipelinePass == null)
+            {
+                m_LensDistortionCrossPipelinePass = new LensDistortionCrossPipelinePass(targetCamera, targetTexture);
+                m_LensDistortionCrossPipelinePass.EnsureActivated();
+            }
+        }
+
+        public LensDistortionPass()
+        {
+            //
+        }
+
+        protected override void Setup(ScriptableRenderContext renderContext, CommandBuffer cmd)
+        {
+            EnsureInit();
+            m_LensDistortionCrossPipelinePass.Setup();
+        }
+
+        protected override void Execute(ScriptableRenderContext renderContext, CommandBuffer cmd, HDCamera hdCamera, CullingResults cullingResult)
+        {
+            CoreUtils.SetRenderTarget(cmd, targetTexture);
+            m_LensDistortionCrossPipelinePass.Execute(renderContext, cmd, hdCamera.camera, cullingResult);
+        }
+    }
+}
+#endif

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionPass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionPass.cs
@@ -15,7 +15,7 @@ namespace UnityEngine.Perception.GroundTruth
         public RenderTexture targetTexture;
         public Camera targetCamera;
 
-        public LensDistortionCrossPipelinePass m_LensDistortionCrossPipelinePass;
+        internal LensDistortionCrossPipelinePass m_LensDistortionCrossPipelinePass;
 
         public LensDistortionPass(Camera targetCamera, RenderTexture targetTexture)
         {

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionPass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionPass.cs
@@ -24,7 +24,7 @@ namespace UnityEngine.Perception.GroundTruth
             EnsureInit();
         }
 
-        void EnsureInit()
+        public void EnsureInit()
         {
             if (m_LensDistortionCrossPipelinePass == null)
             {

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionPass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionPass.cs
@@ -15,7 +15,7 @@ namespace UnityEngine.Perception.GroundTruth
         public RenderTexture targetTexture;
         public Camera targetCamera;
 
-        LensDistortionCrossPipelinePass m_LensDistortionCrossPipelinePass;
+        public LensDistortionCrossPipelinePass m_LensDistortionCrossPipelinePass;
 
         public LensDistortionPass(Camera targetCamera, RenderTexture targetTexture)
         {

--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionPass.cs.meta
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionPass.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7f243f0bc64f47db99fb540a718016dc
+timeCreated: 1598041612

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -467,25 +467,6 @@ namespace UnityEngine.Perception.GroundTruth
             return false;
         }
 
-        /// <summary>
-        /// Retrieves the given <see cref="CameraLabeler"/> from the list of labelers under this PerceptionCamera, if it
-        /// is in the list.  Returns null if not found
-        /// </summary>
-        /// <param name="cameraLabeler"></param>
-        /// <returns></returns>
-        public CameraLabeler GetLabeler<T>()
-        {
-            foreach (var labeler in m_Labelers)
-            {
-                if (labeler.GetType() == typeof(T))
-                {
-                    return labeler;
-                }
-            }
-
-            return null;
-        }
-
         internal void OnGroundTruthRendererFeatureRun()
         {
             //only used to confirm that GroundTruthRendererFeature is present in URP

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -396,11 +396,7 @@ namespace UnityEngine.Perception.GroundTruth
             if (UnityEditor.EditorApplication.isPaused)
                 return;
 #endif
-            CaptureRgbData(cam);
-
-            // Capture Lens Distortion
-            //var stack = VolumeManager.instance.stack;
-            //m_LensDistortion = VolumeManager.instance.stack.GetComponent<LensDistortion>();
+            CaptureRgbData(cam)
 
             foreach (var labeler in m_Labelers)
             {

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -398,6 +398,10 @@ namespace UnityEngine.Perception.GroundTruth
 #endif
             CaptureRgbData(cam);
 
+            // Capture Lens Distortion
+            //var stack = VolumeManager.instance.stack;
+            //m_LensDistortion = VolumeManager.instance.stack.GetComponent<LensDistortion>();
+
             foreach (var labeler in m_Labelers)
             {
                 if (!labeler.enabled)

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -467,6 +467,25 @@ namespace UnityEngine.Perception.GroundTruth
             return false;
         }
 
+        /// <summary>
+        /// Retrieves the given <see cref="CameraLabeler"/> from the list of labelers under this PerceptionCamera, if it
+        /// is in the list.  Returns null if not found
+        /// </summary>
+        /// <param name="cameraLabeler"></param>
+        /// <returns></returns>
+        public CameraLabeler GetLabeler<T>()
+        {
+            foreach (var labeler in m_Labelers)
+            {
+                if (labeler.GetType() == typeof(T))
+                {
+                    return labeler;
+                }
+            }
+
+            return null;
+        }
+
         internal void OnGroundTruthRendererFeatureRun()
         {
             //only used to confirm that GroundTruthRendererFeature is present in URP

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -396,7 +396,7 @@ namespace UnityEngine.Perception.GroundTruth
             if (UnityEditor.EditorApplication.isPaused)
                 return;
 #endif
-            CaptureRgbData(cam)
+            CaptureRgbData(cam);
 
             foreach (var labeler in m_Labelers)
             {

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
@@ -35,6 +35,7 @@ namespace UnityEngine.Perception.GroundTruth
             var width = myCamera.pixelWidth;
             var height = myCamera.pixelHeight;
             m_InstanceSegmentationTexture = new RenderTexture(new RenderTextureDescriptor(width, height, GraphicsFormat.R8G8B8A8_UNorm, 8));
+            m_InstanceSegmentationTexture.filterMode = FilterMode.Point;
             m_InstanceSegmentationTexture.name = "InstanceSegmentation";
 
             m_RenderedObjectInfoGenerator = new RenderedObjectInfoGenerator();
@@ -51,6 +52,16 @@ namespace UnityEngine.Perception.GroundTruth
             };
             instanceSegmentationPass.EnsureInit();
             customPassVolume.customPasses.Add(instanceSegmentationPass);
+
+            // TODO: Note - the implementation here differs substantially from how things are done in SemanticSegmentationLalber
+            // Also, the naming convention doesn't line up, shouldn't instance segmentation be a labeller?  At least in
+            // architecture
+            var lensDistortionPass = new LensDistortionPass(GetComponent<Camera>(), m_InstanceSegmentationTexture)
+            {
+                name = "Instance Segmentation Lens Distortion Pass"
+            };
+            lensDistortionPass.EnsureInit();
+            customPassVolume.customPasses.Add(lensDistortionPass);
 #endif
 #if URP_PRESENT
             AddScriptableRenderPass(new InstanceSegmentationUrpPass(myCamera, m_InstanceSegmentationTexture));

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
@@ -62,9 +62,11 @@ namespace UnityEngine.Perception.GroundTruth
             };
             lensDistortionPass.EnsureInit();
             customPassVolume.customPasses.Add(lensDistortionPass);
-#endif
-#if URP_PRESENT
+#elif URP_PRESENT
             AddScriptableRenderPass(new InstanceSegmentationUrpPass(myCamera, m_InstanceSegmentationTexture));
+
+            // Lens Distortion
+            AddScriptableRenderPass(new LensDistortionUrpPass(myCamera, m_InstanceSegmentationTexture));
 #endif
 
             m_InstanceSegmentationReader = new RenderTextureReader<uint>(m_InstanceSegmentationTexture, myCamera, (frameCount, data, tex) =>

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
@@ -2,11 +2,11 @@
 using Unity.Collections;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
-#if HDRP_PRESENT
-using UnityEngine.Rendering.HighDefinition;
-#endif
-#if URP_PRESENT
 
+#if HDRP_PRESENT
+    using UnityEngine.Rendering.HighDefinition;
+#elif URP_PRESENT
+    using UnityEngine.Rendering.Universal;
 #endif
 
 namespace UnityEngine.Perception.GroundTruth
@@ -37,10 +37,12 @@ namespace UnityEngine.Perception.GroundTruth
         LensDistortionUrpPass m_LensDistortionPass;
     #endif
 
+    #if HDRP_PRESENT || URP_PRESENT
         internal void OverrideLensDistortionIntensity(float intensity)
         {
             m_LensDistortionPass.m_LensDistortionCrossPipelinePass.lensDistortionOverride = intensity;
         }
+    #endif
 
         void SetupInstanceSegmentation()
         {

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
@@ -31,7 +31,7 @@ namespace UnityEngine.Perception.GroundTruth
 
     #if HDRP_PRESENT
         InstanceSegmentationPass m_InstanceSegmentationPass;
-        LensDistortionPass m_LensDistortionPass;
+        //LensDistortionPass m_LensDistortionPass;
     #elif URP_PRESENT
         InstanceSegmentationUrpPass m_InstanceSegmentationPass;
         LensDistortionUrpPass m_LensDistortionPass;

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
@@ -37,7 +37,7 @@ namespace UnityEngine.Perception.GroundTruth
         LensDistortionUrpPass m_LensDistortionPass;
     #endif
 
-        public void OverrideLensDistortionIntensity(float intensity)
+        internal void OverrideLensDistortionIntensity(float intensity)
         {
             m_LensDistortionPass.m_LensDistortionCrossPipelinePass.lensDistortionOverride = intensity;
         }
@@ -66,9 +66,6 @@ namespace UnityEngine.Perception.GroundTruth
             m_InstanceSegmentationPass.EnsureInit();
             customPassVolume.customPasses.Add(m_InstanceSegmentationPass);
 
-            // TODO: Note - the implementation here differs substantially from how things are done in SemanticSegmentationLalber
-            // Also, the naming convention doesn't line up, shouldn't instance segmentation be a labeller?  At least in
-            // architecture
             m_LensDistortionPass = new LensDistortionPass(GetComponent<Camera>(), m_InstanceSegmentationTexture)
             {
                 name = "Instance Segmentation Lens Distortion Pass"

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
@@ -31,7 +31,7 @@ namespace UnityEngine.Perception.GroundTruth
 
     #if HDRP_PRESENT
         InstanceSegmentationPass m_InstanceSegmentationPass;
-        //LensDistortionPass m_LensDistortionPass;
+        LensDistortionPass m_LensDistortionPass;
     #elif URP_PRESENT
         InstanceSegmentationUrpPass m_InstanceSegmentationPass;
         LensDistortionUrpPass m_LensDistortionPass;

--- a/com.unity.perception/Runtime/GroundTruth/Resources/InstanceSegmentation.shader
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/InstanceSegmentation.shader
@@ -41,7 +41,12 @@
 
             fixed4 frag (v2f i) : SV_Target
             {
-                return float4(UnpackUIntToFloat((uint)_SegmentationId, 0, 8), UnpackUIntToFloat(_SegmentationId, 8, 8), UnpackUIntToFloat(_SegmentationId, 16, 8), UnpackUIntToFloat(_SegmentationId, 24, 8));
+                return fixed4(
+                    UnpackUIntToFloat((uint)_SegmentationId,  0, 8),
+                    UnpackUIntToFloat((uint)_SegmentationId,  8, 8),
+                    UnpackUIntToFloat((uint)_SegmentationId, 16, 8),
+                    UnpackUIntToFloat((uint)_SegmentationId, 24, 8)
+                );
             }
             ENDCG
         }

--- a/com.unity.perception/Runtime/GroundTruth/Resources/LabeledObjectHistogram.compute
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/LabeledObjectHistogram.compute
@@ -28,19 +28,19 @@ uint SampleSegmentationTexture(uint2 pixelCoord)
     return objectId;
 }
 
-// For each pixel in the segmentation image, set InstanceIdPresenceMask[pixelValue] to 1 
+// For each pixel in the segmentation image, set InstanceIdPresenceMask[pixelValue] to 1
 [numthreads(8,8,1)]
 void PresenseMask (uint3 id : SV_DispatchThreadID)
 {
     uint instanceId = SampleSegmentationTexture(id.xy);
     if (instanceId != 0)
         InstanceIdPresenceMask[instanceId] = 1;
-    
-    //Attempt at packing presense into single bits. Good for memory, bad for perf due to InterlockedOr. 
-     
+
+    //Attempt at packing presense into single bits. Good for memory, bad for perf due to InterlockedOr.
+
     //int bitOffset = objectId % 32;
     //int maskOffset = objectId / 32;
-    
+
     //InterlockedOr(IdPresenceMask[maskOffset], 1 << bitOffset);
 }
 
@@ -63,9 +63,9 @@ void CombineCounts (uint3 id : SV_DispatchThreadID)
     uint mask = InstanceIdPresenceMask[id.x];
     if (mask > 0)
         InterlockedAdd(ClassCounts[InstanceIdToClassId[id.x]], 1);
-        
-    //Attempt at packing presense into single bits. Good for memory, bad for perf due to InterlockedOr in PresenseMask(...). 
-    
+
+    //Attempt at packing presense into single bits. Good for memory, bad for perf due to InterlockedOr in PresenseMask(...).
+
     //int idStart = id.x * 32;
     //for(int i = 0; i < 32 ; i++)
     //{

--- a/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
@@ -1,43 +1,13 @@
 ﻿Shader "Perception/LensDistortion"
 {
-    //Properties
-    //{
-    //    [PerObjectData] _SegmentationId("Segmentation ID", int) = 0
-    //}
 
     Properties
     {
         _MainTex ("Texture", 2D) = "white" {}
     }
 
-    /*
-    HLSLINCLUDE
-        #pragma exclude_renderers gles
-        #pragma multi_compile_local_fragment _ _DISTORTION
-
-        #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
-        #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Filtering.hlsl"
-        //#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
-        //#include "Packages/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl"
-
-        half4 frag(FullscreenVaryings input) : SV_Target
-        {
-            //UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
-
-            float2 uv = UnityStereoTransformScreenSpaceTex(input.uv);
-            float2 uvDistorted = DistortUV(uv);
-
-            half3 color = (0.0).xxx;
-
-            return half4(color, 1.0);
-        }
-
-    ENDHLSL
-    */
-
     SubShader
     {
-        //Tags {  "RenderPipeline" = "UniversalPipeline"}
         Tags { "RenderType" = "Opaque" "LightMode" = "SRP" }
         LOD 100
         ZTest Always ZWrite Off Cull Off

--- a/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
@@ -75,6 +75,8 @@
 
                 // Note: This is taken from the HDRP UberPost shader:
                 // https://github.com/Unity-Technologies/Graphics/blob/master/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
+                // https://github.com/Unity-Technologies/Graphics/blob/257b08bba6c11de0f894e42e811124247a522d3c/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
+
                 // TODO: Include this code somehow since we're really only using the DistortUV call
 
                 float4 _Distortion_Params1;
@@ -89,22 +91,6 @@
 
                 float2 DistortUV(float2 uv)
                 {
-                    // TODO: Grab these from the camera / volume or whatever
-                    //float4 _Distortion_Params1 = float4(0.0f, 0.0f, 1.0f, .5f);
-                    //float4 _Distortion_Params2 = float4(0.0f, 0.25f, 1.0f, 0.713f);;
-
-                    /*float2 DistCenter = float2(0.0f, 0.0f);
-                    float2 DistAxis = float2(1.0f, 1.0f);
-                    //float DistTheta = _Distortion_Params2.x;
-                    //float DistSigma = _Distortion_Params2.y;
-                    float DistScale = 1.0f;
-                    float DistIntensity = 0.713f;*/
-
-                    // https://github.com/Unity-Technologies/Graphics/blob/257b08bba6c11de0f894e42e811124247a522d3c/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
-                    // This will be passed in from CPU eventually
-                    //float DistTheta = (115.0f * (3.14f / 180.0f));
-                    //float DistSigma = 2.0f * tan(DistTheta * 0.5f);
-
                     uv = (uv - 0.5) * DistScale + 0.5;
                     float2 ruv = DistAxis * (uv - 0.5 - DistCenter);
                     float ru = length(float2(ruv));
@@ -125,11 +111,7 @@
                     return uv;
                 }
 
-                //#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
-                //#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Packing.hlsl"
-
                 sampler2D _MainTex;
-                //SamplerState sampler_MainTex;
 
                 fixed4 frag(v2f input) : SV_Target
                 {

--- a/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
@@ -77,15 +77,15 @@
                 // https://github.com/Unity-Technologies/Graphics/blob/master/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
                 // TODO: Include this code somehow since we're really only using the DistortUV call
 
-                //float4 _Distortion_Params1;
-                //float4 _Distortion_Params2;
+                float4 _Distortion_Params1;
+                float4 _Distortion_Params2;
 
-                /*#define DistCenter              _Distortion_Params1.xy
+                #define DistCenter              _Distortion_Params1.xy
                 #define DistAxis                _Distortion_Params1.zw
                 #define DistTheta               _Distortion_Params2.x
                 #define DistSigma               _Distortion_Params2.y
                 #define DistScale               _Distortion_Params2.z
-                #define DistIntensity           _Distortion_Params2.w*/
+                #define DistIntensity           _Distortion_Params2.w
 
                 float2 DistortUV(float2 uv)
                 {
@@ -93,17 +93,17 @@
                     //float4 _Distortion_Params1 = float4(0.0f, 0.0f, 1.0f, .5f);
                     //float4 _Distortion_Params2 = float4(0.0f, 0.25f, 1.0f, 0.713f);;
 
-                    float2 DistCenter = float2(0.0f, 0.0f);
+                    /*float2 DistCenter = float2(0.0f, 0.0f);
                     float2 DistAxis = float2(1.0f, 1.0f);
                     //float DistTheta = _Distortion_Params2.x;
                     //float DistSigma = _Distortion_Params2.y;
                     float DistScale = 1.0f;
-                    float DistIntensity = 0.713f;
+                    float DistIntensity = 0.713f;*/
 
                     // https://github.com/Unity-Technologies/Graphics/blob/257b08bba6c11de0f894e42e811124247a522d3c/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
                     // This will be passed in from CPU eventually
-                    float DistTheta = (115.0f * (3.14f / 180.0f));
-                    float DistSigma = 2.0f * tan(DistTheta * 0.5f);
+                    //float DistTheta = (115.0f * (3.14f / 180.0f));
+                    //float DistSigma = 2.0f * tan(DistTheta * 0.5f);
 
                     uv = (uv - 0.5) * DistScale + 0.5;
                     float2 ruv = DistAxis * (uv - 0.5 - DistCenter);

--- a/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
@@ -1,0 +1,94 @@
+﻿Shader "Perception/LensDistortion"
+{
+    //Properties
+    //{
+    //    [PerObjectData] _SegmentationId("Segmentation ID", int) = 0
+    //}
+
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+    }
+
+    HLSLINCLUDE
+        #pragma exclude_renderers gles
+        #pragma multi_compile_local_fragment _ _DISTORTION
+
+        #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+        #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Filtering.hlsl"
+        //#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+        //#include "Packages/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl"
+
+        TEXTURE2D(_LensDirt_Texture);
+
+        float4 _Distortion_Params1;
+        float4 _Distortion_Params2;
+
+        #define DistCenter              _Distortion_Params1.xy
+        #define DistAxis                _Distortion_Params1.zw
+        #define DistTheta               _Distortion_Params2.x
+        #define DistSigma               _Distortion_Params2.y
+        #define DistScale               _Distortion_Params2.z
+        #define DistIntensity           _Distortion_Params2.w
+
+        float2 DistortUV(float2 uv)
+        {
+            // Note: this variant should never be set with XR
+            #if _DISTORTION
+            {
+                uv = (uv - 0.5) * DistScale + 0.5;
+                float2 ruv = DistAxis * (uv - 0.5 - DistCenter);
+                float ru = length(float2(ruv));
+
+                UNITY_BRANCH
+                if (DistIntensity > 0.0)
+                {
+                    float wu = ru * DistTheta;
+                    ru = tan(wu) * (rcp(ru * DistSigma));
+                    uv = uv + ruv * (ru - 1.0);
+                }
+                else
+                {
+                    ru = rcp(ru) * DistTheta * atan(ru * DistSigma);
+                    uv = uv + ruv * (ru - 1.0);
+                }
+            }
+            #endif
+
+            return uv;
+        }
+
+        half4 Frag(FullscreenVaryings input) : SV_Target
+        {
+            //UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
+
+            float2 uv = UnityStereoTransformScreenSpaceTex(input.uv);
+            float2 uvDistorted = DistortUV(uv);
+
+            half3 color = (0.0).xxx;
+
+            return half4(color, 1.0);
+        }
+
+    ENDHLSL
+
+    SubShader
+    {
+        Tags { "RenderType" = "Opaque" "RenderPipeline" = "UniversalPipeline"}
+        LOD 100
+        ZTest Always ZWrite Off Cull Off
+
+        Pass
+        {
+            // Note: This is taken from the HDRP UberPost shader:
+            // https://github.com/Unity-Technologies/Graphics/blob/master/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
+            // TODO: Include this code somehow since we're really only using the DistortUV call
+            Name "LensDistortion"
+
+            HLSLPROGRAM
+                #pragma vertex FullscreenVert
+                #pragma fragment Frag
+            ENDHLSL
+        }
+    }
+}

--- a/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
@@ -20,44 +20,6 @@
         //#include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
         //#include "Packages/com.unity.render-pipelines.universal/Shaders/PostProcessing/Common.hlsl"
 
-        float4 _Distortion_Params1;
-        float4 _Distortion_Params2;
-
-        #define DistCenter              _Distortion_Params1.xy
-        #define DistAxis                _Distortion_Params1.zw
-        #define DistTheta               _Distortion_Params2.x
-        #define DistSigma               _Distortion_Params2.y
-        #define DistScale               _Distortion_Params2.z
-        #define DistIntensity           _Distortion_Params2.w
-
-
-        float2 DistortUV(float2 uv)
-        {
-            // Note: this variant should never be set with XR
-            #if _DISTORTION
-            {
-                uv = (uv - 0.5) * DistScale + 0.5;
-                float2 ruv = DistAxis * (uv - 0.5 - DistCenter);
-                float ru = length(float2(ruv));
-
-                UNITY_BRANCH
-                if (DistIntensity > 0.0)
-                {
-                    float wu = ru * DistTheta;
-                    ru = tan(wu) * (rcp(ru * DistSigma));
-                    uv = uv + ruv * (ru - 1.0);
-                }
-                else
-                {
-                    ru = rcp(ru) * DistTheta * atan(ru * DistSigma);
-                    uv = uv + ruv * (ru - 1.0);
-                }
-            }
-            #endif
-
-            return uv;
-        }
-
         half4 frag(FullscreenVaryings input) : SV_Target
         {
             //UNITY_SETUP_STEREO_EYE_INDEX_POST_VERTEX(input);
@@ -82,9 +44,7 @@
 
         Pass
         {
-            // Note: This is taken from the HDRP UberPost shader:
-            // https://github.com/Unity-Technologies/Graphics/blob/master/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
-            // TODO: Include this code somehow since we're really only using the DistortUV call
+
             Name "LensDistortion"
 
             CGPROGRAM
@@ -113,11 +73,71 @@
                     return o;
                 }
 
-                sampler2D _MainTex;
+                // Note: This is taken from the HDRP UberPost shader:
+                // https://github.com/Unity-Technologies/Graphics/blob/master/com.unity.render-pipelines.universal/Shaders/PostProcessing/UberPost.shader
+                // TODO: Include this code somehow since we're really only using the DistortUV call
 
-                fixed4 frag(v2f i) : SV_Target
+                //float4 _Distortion_Params1;
+                //float4 _Distortion_Params2;
+
+                /*#define DistCenter              _Distortion_Params1.xy
+                #define DistAxis                _Distortion_Params1.zw
+                #define DistTheta               _Distortion_Params2.x
+                #define DistSigma               _Distortion_Params2.y
+                #define DistScale               _Distortion_Params2.z
+                #define DistIntensity           _Distortion_Params2.w*/
+
+                float2 DistortUV(float2 uv)
                 {
-                    return float4(tex2D(_MainTex, i.uv).rgb, 1.0f);
+                    // TODO: Grab these from the camera / volume or whatever
+                    //float4 _Distortion_Params1 = float4(0.0f, 0.0f, 1.0f, .5f);
+                    //float4 _Distortion_Params2 = float4(0.0f, 0.25f, 1.0f, 0.713f);;
+
+                    float2 DistCenter = float2(0.0f, 0.0f);
+                    float2 DistAxis = float2(1.0f, 1.0f);
+                    //float DistTheta = _Distortion_Params2.x;
+                    //float DistSigma = _Distortion_Params2.y;
+                    float DistScale = 1.0f;
+                    float DistIntensity = 0.713f;
+
+                    // https://github.com/Unity-Technologies/Graphics/blob/257b08bba6c11de0f894e42e811124247a522d3c/com.unity.render-pipelines.universal/Runtime/Passes/PostProcessPass.cs
+                    // This will be passed in from CPU eventually
+                    float DistTheta = (115.0f * (3.14f / 180.0f));
+                    float DistSigma = 2.0f * tan(DistTheta * 0.5f);
+
+                    uv = (uv - 0.5) * DistScale + 0.5;
+                    float2 ruv = DistAxis * (uv - 0.5 - DistCenter);
+                    float ru = length(float2(ruv));
+
+                    UNITY_BRANCH
+                    if (DistIntensity > 0.0)
+                    {
+                        float wu = ru * DistTheta;
+                        ru = tan(wu) * (rcp(ru * DistSigma));
+                        uv = uv + ruv * (ru - 1.0);
+                    }
+                    else
+                    {
+                        ru = rcp(ru) * DistTheta * atan(ru * DistSigma);
+                        uv = uv + ruv * (ru - 1.0);
+                    }
+
+                    return uv;
+                }
+
+                //#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
+                //#include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Packing.hlsl"
+
+                sampler2D _MainTex;
+                //SamplerState sampler_MainTex;
+
+                fixed4 frag(v2f input) : SV_Target
+                {
+                    float2 uvDistorted = input.uv;
+                    uvDistorted = DistortUV(uvDistorted);
+                    float4 texValue = tex2D(_MainTex, uvDistorted);
+
+                    return texValue;
                 }
 
             ENDCG

--- a/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader
@@ -7,7 +7,7 @@
 
     Properties
     {
-        _InputTexture ("Texture", 2D) = "white" {}
+        _MainTex ("Texture", 2D) = "white" {}
     }
 
     /*
@@ -113,11 +113,11 @@
                     return o;
                 }
 
-                sampler2D _InputTexture;
+                sampler2D _MainTex;
 
                 fixed4 frag(v2f i) : SV_Target
                 {
-                    return float4(tex2D(_InputTexture, i.uv).rgb, 1.0f);
+                    return float4(tex2D(_MainTex, i.uv).rgb, 1.0f);
                 }
 
             ENDCG

--- a/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader.meta
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/LensDistortion.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: fc985f5773827c7468c475fd7290d5e7
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Runtime/GroundTruth/Resources/SemanticSegmentation.shader
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/SemanticSegmentation.shader
@@ -32,32 +32,32 @@
 
             CGPROGRAM
 
-            #pragma vertex vert
-            #pragma fragment frag
+            #pragma vertex semanticSegmentationVertexStage
+            #pragma fragment semanticSegmentationFragmentStage
 
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Common.hlsl"
             #include "Packages/com.unity.render-pipelines.core/ShaderLibrary/Packing.hlsl"
 
             float4 LabelingId;
 
-            struct appdata
+            struct in_vert
             {
                 float4 vertex : POSITION;
             };
 
-            struct v2f
+            struct vertexToFragment
             {
                 float4 vertex : SV_POSITION;
             };
 
-            v2f vert (appdata v)
+            vertexToFragment semanticSegmentationVertexStage (in_vert vertWorldSpace)
             {
-                v2f o;
-                o.vertex = UnityObjectToClipPos(v.vertex);
-                return o;
+                vertexToFragment vertScreenSpace;
+                vertScreenSpace.vertex = UnityObjectToClipPos(vertWorldSpace.vertex);
+                return vertScreenSpace;
             }
 
-            fixed4 frag (v2f i) : SV_Target
+            fixed4 semanticSegmentationFragmentStage (vertexToFragment vertScreenSpace) : SV_Target
             {
                 return LabelingId;
             }

--- a/com.unity.perception/Runtime/GroundTruth/SemanticSegmentationCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SemanticSegmentationCrossPipelinePass.cs
@@ -15,6 +15,8 @@ namespace UnityEngine.Perception.GroundTruth
 
         static int s_LastFrameExecuted = -1;
 
+        const string k_LensDistortionShaderName = "Perception/LensDistortion";
+
         SemanticSegmentationLabelConfig m_LabelConfig;
 
         //Serialize the shader so that the shader asset is included in player builds when the SemanticSegmentationPass is used.
@@ -23,6 +25,9 @@ namespace UnityEngine.Perception.GroundTruth
         //[SerializeField]
         Shader m_ClassLabelingShader;
         Material m_OverrideMaterial;
+
+        private Shader m_LensDistortionShader;
+        private Material m_LensDistortionMaterial;
 
         public SemanticSegmentationCrossPipelinePass(Camera targetCamera, SemanticSegmentationLabelConfig labelConfig) : base(targetCamera)
         {
@@ -33,11 +38,23 @@ namespace UnityEngine.Perception.GroundTruth
         {
             base.Setup();
             m_ClassLabelingShader = Shader.Find(k_ShaderName);
+
             var shaderVariantCollection = new ShaderVariantCollection();
-            shaderVariantCollection.Add(new ShaderVariantCollection.ShaderVariant(m_ClassLabelingShader, PassType.ScriptableRenderPipeline));
-            shaderVariantCollection.WarmUp();
+
+            if (shaderVariantCollection != null)
+                shaderVariantCollection.Add(new ShaderVariantCollection.ShaderVariant(m_ClassLabelingShader, PassType.ScriptableRenderPipeline));
 
             m_OverrideMaterial = new Material(m_ClassLabelingShader);
+
+            // Lens Distortion
+            m_LensDistortionShader = Shader.Find(k_LensDistortionShaderName);
+            if (shaderVariantCollection != null)
+                shaderVariantCollection.Add(new ShaderVariantCollection.ShaderVariant(m_LensDistortionShader, PassType.ScriptableRenderPipeline));
+
+            m_LensDistortionMaterial = new Material(m_LensDistortionShader);
+
+            if(shaderVariantCollection != null)
+                shaderVariantCollection.WarmUp();
         }
 
         protected override void ExecutePass(ScriptableRenderContext renderContext, CommandBuffer cmd, Camera camera, CullingResults cullingResult)

--- a/com.unity.perception/Runtime/GroundTruth/SemanticSegmentationCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SemanticSegmentationCrossPipelinePass.cs
@@ -43,10 +43,7 @@ namespace UnityEngine.Perception.GroundTruth
 
             m_OverrideMaterial = new Material(m_ClassLabelingShader);
 
-            if (shaderVariantCollection != null)
-            {
-                shaderVariantCollection.WarmUp();
-            }
+            shaderVariantCollection.WarmUp();
         }
 
         protected override void ExecutePass(ScriptableRenderContext renderContext, CommandBuffer cmd, Camera camera, CullingResults cullingResult)

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/SegmentationGroundTruthTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/SegmentationGroundTruthTests.cs
@@ -168,7 +168,7 @@ namespace GroundTruthTests
 
                     boundingBoxWithoutLensDistortion = boundingBoxes[0].boundingBox;
 
-                    // Add this
+                    // Add lens distortion
                     perceptionCamera.OverrideLensDistortionIntensity(0.715f);
 
                     frames = 0;

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/SegmentationGroundTruthTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/SegmentationGroundTruthTests.cs
@@ -9,7 +9,6 @@ using UnityEngine;
 using UnityEngine.Perception.GroundTruth;
 using UnityEngine.Rendering;
 
-
 #if HDRP_PRESENT
     using UnityEngine.Rendering.HighDefinition;
 #elif URP_PRESENT
@@ -130,6 +129,9 @@ namespace GroundTruthTests
             Assert.AreEqual(4, timesSegmentationImageReceived);
         }
 
+        // Lens Distortion is only applicable in URP or HDRP pipelines
+        // As such, this test will always fail if URP or HDRP are not present (and also not really compile either)
+#if HDRP_PRESENT || URP_PRESENT
         [UnityTest]
         public IEnumerator SemanticSegmentationPass_WithLensDistortion()
         {
@@ -210,6 +212,7 @@ namespace GroundTruthTests
             DestroyTestObject(cameraObject);
             DestroyTestObject(planeObject);
         }
+#endif // ! HDRP_PRESENT || URP_PRESENT
 
         [UnityTest]
         public IEnumerator SemanticSegmentationPass_WithLabeledButNotMatchingObject_ProducesBlack()


### PR DESCRIPTION
# Peer Review Information:
These changes introduce a Lens Distortion pass that is included in both semantic and instance segmentation flows.  This has been tested for both URP and HDRP, utilizing a camera that enabled post-processing with a Global Volume that overrides the Lens Distortion parameters.  This is unlikely to be the way we would like to do these effects in the long run, but at least for the time being allow ground truth to be correctly distorted per the parameters of the distortion applied to the RGB images.  

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
SemanticSegmentationPass_WithLensDistortion

**Core Scenario Tested**: 
Test involves running the actual lens distortion shader on a captured instance segmentation mask and with and without "intensity" (which is what resolves into the actual distortion of the effect) and then ensuring the two calculated bounding boxes are not equivalent as well as making sure that the distorted bounding box with bigger (since barrel distortion is applied for intensity values over 0.5).  This test does differ slightly from the core-pipeline as it utilizes a Lens Distortion override for the pass - which essentially then defaults the values vs. using them from the volume, as the VolumeManager was not clearly accessible from the test framework (would have led to a different test for HDRP vs. URP as well, so this was more eloquent). 

**At Risk Areas**: 
The actual distortion is "lifted" from the respective UberPost shader / PostProcessing.cs implementation, so this is a limitation of these changes.  It was not obvious how to utilize these capabilities without cargo-coding these aspects, and this actually came in handy as the implementation was manipulated to allow for some generality for test purposes. 

**Notes + Expectations**: 

## Checklist
- [x] - Updated docs
- [x] - Updated changelog
