### PR TITLE
Updating simulation.capture to preview.13

### DIFF
--- a/TestProjects/PerceptionHDRP/Packages/manifest.json
+++ b/TestProjects/PerceptionHDRP/Packages/manifest.json
@@ -8,7 +8,7 @@
     "com.unity.perception": "file:../../../com.unity.perception",
     "com.unity.render-pipelines.core": "7.3.1",
     "com.unity.render-pipelines.high-definition": "7.3.1",
-    "com.unity.simulation.capture": "0.0.10-preview.12",
+    "com.unity.simulation.capture": "0.0.10-preview.13",
     "com.unity.simulation.core": "0.0.10-preview.19",
     "com.unity.test-framework": "1.1.16",
     "com.unity.testtools.codecoverage": "0.2.2-preview",

--- a/TestProjects/PerceptionHDRP/Packages/packages-lock.json
+++ b/TestProjects/PerceptionHDRP/Packages/packages-lock.json
@@ -107,7 +107,7 @@
         "com.unity.nuget.newtonsoft-json": "1.1.2",
         "com.unity.render-pipelines.core": "7.1.6",
         "com.unity.entities": "0.8.0-preview.8",
-        "com.unity.simulation.capture": "0.0.10-preview.12",
+        "com.unity.simulation.capture": "0.0.10-preview.13",
         "com.unity.simulation.core": "0.0.10-preview.19"
       }
     },
@@ -201,7 +201,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.simulation.capture": {
-      "version": "0.0.10-preview.12",
+      "version": "0.0.10-preview.13",
       "depth": 0,
       "source": "registry",
       "dependencies": {

--- a/TestProjects/PerceptionURP/Packages/manifest.json
+++ b/TestProjects/PerceptionURP/Packages/manifest.json
@@ -6,7 +6,7 @@
     "com.unity.package-validation-suite": "0.9.1-preview",
     "com.unity.perception": "file:../../../com.unity.perception",
     "com.unity.render-pipelines.universal": "7.3.1",
-    "com.unity.simulation.capture": "0.0.10-preview.12",
+    "com.unity.simulation.capture": "0.0.10-preview.13",
     "com.unity.simulation.core": "0.0.10-preview.19",
     "com.unity.test-framework": "1.1.16",
     "com.unity.textmeshpro": "2.0.1",

--- a/TestProjects/PerceptionURP/Packages/packages-lock.json
+++ b/TestProjects/PerceptionURP/Packages/packages-lock.json
@@ -107,7 +107,7 @@
         "com.unity.nuget.newtonsoft-json": "1.1.2",
         "com.unity.render-pipelines.core": "7.1.6",
         "com.unity.entities": "0.8.0-preview.8",
-        "com.unity.simulation.capture": "0.0.10-preview.12",
+        "com.unity.simulation.capture": "0.0.10-preview.13",
         "com.unity.simulation.core": "0.0.10-preview.19"
       }
     },
@@ -190,12 +190,13 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.simulation.capture": {
-      "version": "file:com.unity.simulation.capture",
+      "version": "0.0.10-preview.13",
       "depth": 0,
-      "source": "embedded",
+      "source": "registry",
       "dependencies": {
         "com.unity.simulation.core": "0.0.10-preview.19"
-      }
+      },
+      "url": "https://packages.unity.com"
     },
     "com.unity.simulation.core": {
       "version": "0.0.10-preview.19",

--- a/com.unity.perception/package.json
+++ b/com.unity.perception/package.json
@@ -3,7 +3,7 @@
     "com.unity.nuget.newtonsoft-json": "1.1.2",
     "com.unity.render-pipelines.core": "7.1.6",
     "com.unity.entities": "0.8.0-preview.8",
-    "com.unity.simulation.capture": "0.0.10-preview.12",
+    "com.unity.simulation.capture": "0.0.10-preview.13",
     "com.unity.simulation.core": "0.0.10-preview.19"
   },
   "description": "Tools for generating large-scale data sets for perception-based machine learning training and validation",


### PR DESCRIPTION
# Peer Review Information:
Small change - upgrading to simulation.capture to preview.13 to address intermittent shader compilation error on URP projects.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
