### PR TITLE
Bugfix: Resolving issue with Lens Distortion in URP when Post Processing enabled, but no global override

### DIFF
--- a/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LensDistortionCrossPipelinePass.cs
@@ -130,8 +130,14 @@ namespace UnityEngine.Perception.GroundTruth
             if(targetCamera == null)
                 return false;
 
-            if(targetCamera.GetUniversalAdditionalCameraData().renderPostProcessing == false && lensDistortionOverride.HasValue == false)
+            var UACD = targetCamera.GetUniversalAdditionalCameraData();
+
+            if(UACD.renderPostProcessing == false && lensDistortionOverride.HasValue == false)
                 return false;
+
+            if (m_lensDistortion.active == false)
+                return false;
+
         #else
             return false;
         #endif
@@ -152,6 +158,10 @@ namespace UnityEngine.Perception.GroundTruth
                     mult.x = Mathf.Max(m_lensDistortion.xMultiplier.value, 1e-4f);
                     mult.y = Mathf.Max(m_lensDistortion.yMultiplier.value, 1e-4f);
                     scale = 1.0f / m_lensDistortion.scale.value;
+                }
+                else
+                {
+                    return false;
                 }
             }
 


### PR DESCRIPTION
# Peer Review Information:
This change resolves the issue with lens distortion in URP where the post processing flag has been set for a camera, but no global override is present to actually set the lens distortion parameters. Also nice-ifyed the logic a bit. 

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
