### PR TITLE
Fixing labeling on per-material MaterialPropertyBlocks

### DIFF
--- a/TestProjects/PerceptionURP/Assets/Scenes/SampleScene.meta
+++ b/TestProjects/PerceptionURP/Assets/Scenes/SampleScene.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c63d11a708fe3f047a545d7e457f6e81
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/PerceptionURP/Assets/Scenes/SampleScene.unity
+++ b/TestProjects/PerceptionURP/Assets/Scenes/SampleScene.unity
@@ -135,6 +135,7 @@ GameObject:
   - component: {fileID: 411238278}
   - component: {fileID: 411238277}
   - component: {fileID: 411238282}
+  - component: {fileID: 411238283}
   m_Layer: 0
   m_Name: Crate
   m_TagString: Untagged
@@ -243,6 +244,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   yDegreesPerSecond: 180
+--- !u!114 &411238283
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 411238276}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 695e410829600ff40bcdd76fa0818f6a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  materialPropertyTarget: 1
+  color: {r: 0.745283, g: 0.40428087, b: 0.40428087, a: 0}
 --- !u!1 &464025704
 GameObject:
   m_ObjectHideFlags: 0
@@ -257,6 +272,7 @@ GameObject:
   - component: {fileID: 464025706}
   - component: {fileID: 464025705}
   - component: {fileID: 464025710}
+  - component: {fileID: 464025711}
   m_Layer: 0
   m_Name: Cube
   m_TagString: Untagged
@@ -309,6 +325,8 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
   - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
   m_StaticBatchInfo:
     firstSubMesh: 0
@@ -365,6 +383,20 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   yDegreesPerSecond: 180
+--- !u!114 &464025711
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464025704}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 695e410829600ff40bcdd76fa0818f6a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  materialPropertyTarget: 1
+  color: {r: 0.34109113, g: 0.42664438, b: 0.6886792, a: 0}
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -595,7 +627,7 @@ MonoBehaviour:
   - id: 1
   - id: 2
   - id: 3
-  showVisualizations: 0
+  showVisualizations: 1
   references:
     version: 1
     00000000:

--- a/TestProjects/PerceptionURP/Assets/TestMpbPerMaterial.cs
+++ b/TestProjects/PerceptionURP/Assets/TestMpbPerMaterial.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum MaterialPropertyTarget
+{
+    Renderer,
+    Material
+}
+[ExecuteInEditMode]
+public class TestMpbPerMaterial : MonoBehaviour
+{
+    public MaterialPropertyTarget materialPropertyTarget = MaterialPropertyTarget.Material;
+    public Color color;
+    // Update is called once per frame
+    void Start()
+    {
+        var meshRenderer = GetComponent<MeshRenderer>();
+        MaterialPropertyBlock mpb = new MaterialPropertyBlock();
+        mpb.SetColor("_BaseColor", color);
+        if (materialPropertyTarget == MaterialPropertyTarget.Renderer)
+            meshRenderer.SetPropertyBlock(mpb);
+        else
+        {
+            for (int i = 0; i < meshRenderer.sharedMaterials.Length; i++)
+            {
+                meshRenderer.SetPropertyBlock(mpb, i);
+            }
+        }
+    }
+}

--- a/TestProjects/PerceptionURP/Assets/TestMpbPerMaterial.cs.meta
+++ b/TestProjects/PerceptionURP/Assets/TestMpbPerMaterial.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 695e410829600ff40bcdd76fa0818f6a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TestProjects/PerceptionURP/ProjectSettings/QualitySettings.asset
+++ b/TestProjects/PerceptionURP/ProjectSettings/QualitySettings.asset
@@ -95,7 +95,7 @@ QualitySettings:
     skinWeights: 2
     textureQuality: 0
     anisotropicTextures: 1
-    antiAliasing: 0
+    antiAliasing: 2
     softParticles: 0
     softVegetation: 1
     realtimeReflectionProbes: 1

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -12,6 +12,10 @@ Added new randomization tools
 
 Added support for 2020.1
 
+Added Labeling.RefreshLabeling(), which can be used to update ground truth generators after the list of labels or the renderers is changed
+
+Added support for renderers with MaterialPropertyBlocks assigned to individual materials
+
 ### Changed
 
 Changed the way realtime visualizers rendered to avoid rendering conflicts

--- a/com.unity.perception/Runtime/GroundTruth/GroundTruthLabelSetupSystem.cs
+++ b/com.unity.perception/Runtime/GroundTruth/GroundTruthLabelSetupSystem.cs
@@ -70,6 +70,20 @@ namespace UnityEngine.Perception.GroundTruth
                     pass.SetupMaterialProperties(mpb, renderer, labeling, instanceId);
 
                 renderer.SetPropertyBlock(mpb);
+
+                var materialCount = renderer.materials.Length;
+                for (int i = 0; i < materialCount; i++)
+                {
+                    renderer.GetPropertyBlock(mpb, i);
+                    //Only apply to individual materials if there is already a MaterialPropertyBlock on it
+                    if (!mpb.isEmpty)
+                    {
+                        foreach (var pass in m_ActiveGenerators)
+                            pass.SetupMaterialProperties(mpb, renderer, labeling, instanceId);
+
+                        renderer.SetPropertyBlock(mpb, i);
+                    }
+                }
             }
 
             for (var i = 0; i < gameObject.transform.childCount; i++)
@@ -105,6 +119,11 @@ namespace UnityEngine.Perception.GroundTruth
         public bool Deactivate(IGroundTruthGenerator generator)
         {
             return m_ActiveGenerators.Remove(generator);
+        }
+
+        internal void RefreshLabeling(Entity labelingEntity)
+        {
+            EntityManager.RemoveComponent<GroundTruthInfo>(labelingEntity);
         }
     }
 }

--- a/com.unity.perception/Runtime/GroundTruth/Labeling/Labeling.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labeling/Labeling.cs
@@ -12,7 +12,7 @@ namespace UnityEngine.Perception.GroundTruth
     public class Labeling : MonoBehaviour
     {
         /// <summary>
-        /// The label names to associate with the GameObject. Modifications to this list after the Update() step of the frame the object is created in are 
+        /// The label names to associate with the GameObject. Modifications to this list after the Update() step of the frame the object is created in are
         /// not guaranteed to be reflected by labelers.
         /// </summary>
         [FormerlySerializedAs("classes")]
@@ -36,6 +36,15 @@ namespace UnityEngine.Perception.GroundTruth
         {
             if (World.DefaultGameObjectInjectionWorld != null)
                 World.DefaultGameObjectInjectionWorld.EntityManager.DestroyEntity(m_Entity);
+        }
+
+        /// <summary>
+        /// Refresh ground truth generation for the labeling of the attached GameObject. This is necessary when the
+        /// list of labels changes or when renderers or materials change on objects in the hierarchy.
+        /// </summary>
+        public void RefreshLabeling()
+        {
+            World.DefaultGameObjectInjectionWorld.GetOrCreateSystem<GroundTruthLabelSetupSystem>().RefreshLabeling(m_Entity);
         }
     }
 }

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/TestHelper.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/TestHelper.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Diagnostics;
 using System.Text.RegularExpressions;
+using Unity.Collections;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
 using UnityEngine.Perception.GroundTruth;
 
 namespace GroundTruthTests
@@ -16,6 +19,21 @@ namespace GroundTruthTests
             var labeling = planeObject.AddComponent<Labeling>();
             labeling.labels.Add(label);
             return planeObject;
+        }
+
+        public static void ReadRenderTextureRawData<T>(RenderTexture renderTexture, Action<NativeArray<T>> callback) where T : struct
+        {
+            RenderTexture.active = renderTexture;
+
+            var cpuTexture = new Texture2D(renderTexture.width, renderTexture.height, renderTexture.graphicsFormat, TextureCreationFlags.None);
+
+            cpuTexture.ReadPixels(new Rect(
+                    Vector2.zero,
+                    new Vector2(renderTexture.width, renderTexture.height)),
+                0, 0);
+            RenderTexture.active = null;
+            var data = cpuTexture.GetRawTextureData<T>();
+            callback(data);
         }
 
 #if UNITY_EDITOR


### PR DESCRIPTION
# Peer Review Information:
Fixing labeling on per-material MaterialPropertyBlocks. Also supporting refreshing labeling manually after making changes to renderers or the Labeling component.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
Added tests for refreshing labeling and material property blocks on individual materials and on renderers themselves.
Added material property blocks to the cubes in the test scene.

**Core Scenario Tested**: 
Tested in PerceptionURP and in SynthDet.

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
