### PR TITLE
Changed the namespace of randomization tools to UnityEngine.Experimental

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -20,7 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [0.4.0-preview.1] - 2020-08-07
 
 ### Added
-Added new randomization tools
+
+Added new experimental randomization tools
 
 Added support for 2020.1
 

--- a/com.unity.perception/Documentation~/Randomization/Index.md
+++ b/com.unity.perception/Documentation~/Randomization/Index.md
@@ -1,5 +1,7 @@
 # Overview
 
+*NOTICE: The perception randomization toolset is currently marked as experimental and will experience a number of updates in the near future.*
+
 The randomization toolset simplifies randomizing aspects of generating synthetic data. It facilitates exposing parameters for randomization, offers samplers to pick random values from parameters, and provides scenarios to define a full randomization process. Each of these also allows for custom implementations to fit particular randomization needs.
 
 **What is Domain Randomization?**

--- a/com.unity.perception/Documentation~/index.md
+++ b/com.unity.perception/Documentation~/index.md
@@ -9,7 +9,7 @@ The Perception package provides a toolkit for generating large-scale datasets fo
 
 [Setting up your first perception scene](GettingStarted.md)
 
-[Randomizing your simulation](Randomization/Index.md)
+[Randomizing your simulation (Experimental)](Randomization/Index.md)
 
 ## Example projects using Perception
 
@@ -32,7 +32,7 @@ The [Unity Simulation Smart Camera Example](https://github.com/Unity-Technologie
 |[LabelConfig](GroundTruth-Labeling.md#LabelConfig)|Asset which defines a taxonomy of labels for ground truth generation|
 |[Perception Camera](PerceptionCamera.md)|Captures RGB images and ground truth from a [Camera](https://docs.unity3d.com/Manual/class-Camera.html)|
 |[DatasetCapture](DatasetCapture.md)|Ensures sensors are triggered at proper rates and accepts data for the JSON dataset|
-|[Randomization](Randomization/Index.md)|Integrate domain randomization principles into your simulation|
+|[Randomization (Experimental)](Randomization/Index.md)|Integrate domain randomization principles into your simulation|
 
 ## Known Issues
 

--- a/com.unity.perception/Editor/Randomization/CategoricalOptionElement.cs
+++ b/com.unity.perception/Editor/Randomization/CategoricalOptionElement.cs
@@ -3,7 +3,7 @@ using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 
-namespace UnityEngine.Perception.Randomization.Editor
+namespace UnityEngine.Experimental.Perception.Randomization.Editor
 {
     class CategoricalOptionElement : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/FloatRangeElement.cs
+++ b/com.unity.perception/Editor/Randomization/FloatRangeElement.cs
@@ -3,7 +3,7 @@ using UnityEditor;
 using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 
-namespace UnityEngine.Perception.Randomization.Editor
+namespace UnityEngine.Experimental.Perception.Randomization.Editor
 {
     class FloatRangeElement : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/ParameterConfigurationEditor.cs
+++ b/com.unity.perception/Editor/Randomization/ParameterConfigurationEditor.cs
@@ -2,11 +2,11 @@ using System;
 using UnityEngine;
 using UnityEditor;
 using UnityEditor.UIElements;
-using UnityEngine.Perception.Randomization.Configuration;
-using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Configuration;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
 using UnityEngine.UIElements;
 
-namespace UnityEngine.Perception.Randomization.Editor
+namespace UnityEngine.Experimental.Perception.Randomization.Editor
 {
     [CustomEditor(typeof(ParameterConfiguration))]
     class ParameterConfigurationEditor : UnityEditor.Editor

--- a/com.unity.perception/Editor/Randomization/ParameterDragBar.cs
+++ b/com.unity.perception/Editor/Randomization/ParameterDragBar.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine.UIElements;
 
-namespace UnityEngine.Perception.Randomization.Editor
+namespace UnityEngine.Experimental.Perception.Randomization.Editor
 {
     class ParameterDragBar : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/ParameterDragManipulator.cs
+++ b/com.unity.perception/Editor/Randomization/ParameterDragManipulator.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine.UIElements;
 
-namespace UnityEngine.Perception.Randomization.Editor
+namespace UnityEngine.Experimental.Perception.Randomization.Editor
 {
     class ParameterDragManipulator : MouseManipulator
     {

--- a/com.unity.perception/Editor/Randomization/ParameterElement.cs
+++ b/com.unity.perception/Editor/Randomization/ParameterElement.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.UIElements;
-using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
 using UnityEngine.UIElements;
 
-namespace UnityEngine.Perception.Randomization.Editor
+namespace UnityEngine.Experimental.Perception.Randomization.Editor
 {
     class ParameterElement : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/RandomSeedField.cs
+++ b/com.unity.perception/Editor/Randomization/RandomSeedField.cs
@@ -2,7 +2,7 @@
 using UnityEditor.UIElements;
 using UnityEngine.UIElements;
 
-namespace UnityEngine.Perception.Randomization.Editor
+namespace UnityEngine.Experimental.Perception.Randomization.Editor
 {
     class RandomSeedField : IntegerField
     {

--- a/com.unity.perception/Editor/Randomization/SamplerElement.cs
+++ b/com.unity.perception/Editor/Randomization/SamplerElement.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using UnityEditor;
 using UnityEditor.UIElements;
-using UnityEngine.Perception.Randomization.Parameters;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 using UnityEngine.UIElements;
 
-namespace UnityEngine.Perception.Randomization.Editor
+namespace UnityEngine.Experimental.Perception.Randomization.Editor
 {
     class SamplerElement : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/ScenarioBaseEditor.cs
+++ b/com.unity.perception/Editor/Randomization/ScenarioBaseEditor.cs
@@ -1,9 +1,9 @@
 ﻿using UnityEditor;
 using UnityEditor.UIElements;
-using UnityEngine.Perception.Randomization.Scenarios;
+using UnityEngine.Experimental.Perception.Randomization.Scenarios;
 using UnityEngine.UIElements;
 
-namespace UnityEngine.Perception.Randomization.Editor
+namespace UnityEngine.Experimental.Perception.Randomization.Editor
 {
     [CustomEditor(typeof(ScenarioBase), true)]
     class ScenarioBaseEditor : UnityEditor.Editor

--- a/com.unity.perception/Editor/Randomization/StaticData.cs
+++ b/com.unity.perception/Editor/Randomization/StaticData.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEditor;
-using UnityEngine.Perception.Randomization.Parameters;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Editor
+namespace UnityEngine.Experimental.Perception.Randomization.Editor
 {
     static class StaticData
     {

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -1,18 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using Unity.Collections;
-using Unity.Collections.LowLevel.Unsafe;
 using Unity.Profiling;
 using Unity.Simulation;
 using UnityEngine;
 using UnityEngine.Experimental.Rendering;
-using UnityEngine.Perception.Randomization.Scenarios;
 using UnityEngine.Profiling;
 using UnityEngine.Rendering;
-using UnityEngine.Serialization;
-using UnityEngine.UI;
 #if HDRP_PRESENT
 using UnityEngine.Rendering.HighDefinition;
 #endif

--- a/com.unity.perception/Runtime/Randomization/Configuration/ParameterConfiguration.cs
+++ b/com.unity.perception/Runtime/Randomization/Configuration/ParameterConfiguration.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
 
-namespace UnityEngine.Perception.Randomization.Configuration
+namespace UnityEngine.Experimental.Perception.Randomization.Configuration
 {
     /// <summary>
     /// Creates parameter interfaces for randomizing simulations

--- a/com.unity.perception/Runtime/Randomization/Configuration/ParameterConfigurationException.cs
+++ b/com.unity.perception/Runtime/Randomization/Configuration/ParameterConfigurationException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Perception.Randomization.Configuration
+namespace UnityEngine.Experimental.Perception.Randomization.Configuration
 {
     [Serializable]
     class ParameterConfigurationException : Exception

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// Generates samples by choosing one option from a list of choices

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameterBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameterBase.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// The base class of CategoricalParameters.

--- a/com.unity.perception/Runtime/Randomization/Parameters/NumericParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/NumericParameter.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// Numeric parameters use samplers to generate randomized structs

--- a/com.unity.perception/Runtime/Randomization/Parameters/Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/Parameter.cs
@@ -1,8 +1,8 @@
 using System;
 using UnityEngine;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// Parameters, in conjunction with a parameter configuration, are used to create convenient interfaces for

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTarget.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTarget.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// Used to apply sampled parameter values to a particular GameObject, Component, and property.

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/BooleanParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/BooleanParameter.cs
@@ -2,9 +2,9 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating boolean samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/ColorHsvaParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/ColorHsvaParameter.cs
@@ -2,9 +2,9 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating Color samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/FloatParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/FloatParameter.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating float samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/GameObjectParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/GameObjectParameter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A categorical parameter for generating GameObject samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/IntegerParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/IntegerParameter.cs
@@ -2,9 +2,9 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating integer samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/MaterialParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/MaterialParameter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A categorical parameter for generating Material samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/StringParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/StringParameter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A categorical parameter for generating string samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/Vector2Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/Vector2Parameter.cs
@@ -2,9 +2,9 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating Vector2 samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/Vector3Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/Vector3Parameter.cs
@@ -2,9 +2,9 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating Vector3 samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/Vector4Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/Vector4Parameter.cs
@@ -2,9 +2,9 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating Vector4 samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterValidationException.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterValidationException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Perception.Randomization.Parameters
+namespace UnityEngine.Experimental.Perception.Randomization.Parameters
 {
     class ParameterValidationException : Exception
     {

--- a/com.unity.perception/Runtime/Randomization/Samplers/FloatRange.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/FloatRange.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Unity.Assertions;
 
-namespace UnityEngine.Perception.Randomization.Samplers
+namespace UnityEngine.Experimental.Perception.Randomization.Samplers
 {
     /// <summary>
     /// A struct representing a continuous range of values

--- a/com.unity.perception/Runtime/Randomization/Samplers/ISampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/ISampler.cs
@@ -3,7 +3,7 @@ using Unity.Collections;
 using Unity.Jobs;
 using UnityEngine;
 
-namespace UnityEngine.Perception.Randomization.Samplers
+namespace UnityEngine.Experimental.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Generates random values from probability distributions

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
@@ -2,7 +2,7 @@
 using Unity.Collections;
 using Unity.Jobs;
 
-namespace UnityEngine.Perception.Randomization.Samplers
+namespace UnityEngine.Experimental.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Returns a constant value when sampled

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
@@ -2,7 +2,7 @@
 using Unity.Collections;
 using Unity.Jobs;
 
-namespace UnityEngine.Perception.Randomization.Samplers
+namespace UnityEngine.Experimental.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Returns normally distributed random values bounded within a specified range

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
@@ -3,7 +3,7 @@ using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
 
-namespace UnityEngine.Perception.Randomization.Samplers
+namespace UnityEngine.Experimental.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Returns uniformly distributed random values within a designated range.

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
@@ -5,7 +5,7 @@ using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
 
-namespace UnityEngine.Perception.Randomization.Samplers
+namespace UnityEngine.Experimental.Perception.Randomization.Samplers
 {
     /// <summary>
     /// A set of utility functions for defining sampler interfaces

--- a/com.unity.perception/Runtime/Randomization/Scenarios/FixedLengthScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/FixedLengthScenario.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace UnityEngine.Perception.Randomization.Scenarios
+namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
 {
     /// <summary>
     /// A scenario that runs for a fixed number of frames during each iteration

--- a/com.unity.perception/Runtime/Randomization/Scenarios/Scenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/Scenario.cs
@@ -1,6 +1,6 @@
 ﻿using System.IO;
 
-namespace UnityEngine.Perception.Randomization.Scenarios
+namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
 {
     /// <summary>
     /// The base class of scenarios with serializable constants

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -1,10 +1,10 @@
 using System;
 using UnityEngine;
 using UnityEngine.Perception.GroundTruth;
-using UnityEngine.Perception.Randomization.Configuration;
-using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Configuration;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
 
-namespace UnityEngine.Perception.Randomization.Scenarios
+namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
 {
     /// <summary>
     /// The base class of all scenario classes

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioException.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Perception.Randomization.Scenarios
+namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
 {
     [Serializable]
     class ScenarioException : Exception

--- a/com.unity.perception/Tests/Runtime/Randomization/ParameterConfigurationTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ParameterConfigurationTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Perception.Randomization.Configuration;
-using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Configuration;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
 using UnityEngine.TestTools;
 
 namespace RandomizationTests

--- a/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/CategoricalParameterTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/CategoricalParameterTests.cs
@@ -1,6 +1,6 @@
 ﻿using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
 
 namespace RandomizationTests.ParameterTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/GenericParameterTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/GenericParameterTests.cs
@@ -1,6 +1,6 @@
 ﻿using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
 
 namespace RandomizationTests.ParameterTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/StructParameterTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/StructParameterTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
 using Object = UnityEngine.Object;
 
 namespace RandomizationTests.ParameterTests

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/ConstantSamplerTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/ConstantSamplerTests.cs
@@ -1,5 +1,5 @@
 ﻿using NUnit.Framework;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/FloatRangeTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/FloatRangeTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/NormalSamplerTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/NormalSamplerTests.cs
@@ -1,5 +1,5 @@
 ﻿using NUnit.Framework;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/SamplerTestsBase.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/SamplerTestsBase.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/SamplerUtilityTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/SamplerUtilityTests.cs
@@ -1,5 +1,5 @@
 ﻿using NUnit.Framework;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/UniformSamplerTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/UniformSamplerTests.cs
@@ -1,5 +1,5 @@
 ﻿using NUnit.Framework;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/ScenarioTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ScenarioTests.cs
@@ -4,10 +4,10 @@ using System.IO;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.Perception.GroundTruth;
-using UnityEngine.Perception.Randomization.Configuration;
-using UnityEngine.Perception.Randomization.Parameters;
-using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Perception.Randomization.Scenarios;
+using UnityEngine.Experimental.Perception.Randomization.Configuration;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Experimental.Perception.Randomization.Scenarios;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 


### PR DESCRIPTION
# Peer Review Information:
To reflect the experimental nature of the current randomization tools, the namespace of all randomization classes will now include the "Experimental" namespace, as per Unity convention.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [✓] - Updated docs
- [✓] - Updated changelog
