### PR TITLE
Disabled 2020.1 tests for 0.5.0 release

### DIFF
--- a/.yamato/environments.yml
+++ b/.yamato/environments.yml
@@ -11,7 +11,7 @@ per_commit_editors:
 
 complete_editors:
   - version: 2019.4.6f1
-  - version: 2020.1.3f1
+#  - version: 2020.1.3f1
 #  - version: 2020.2.0a21
 
 publish_platforms:

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [0.5.0-preview.1] - 2020-10-14
 
+### Known Issues
+
+Creating a new 2020.1.x project and adding the perception package to the project causes a memory error that is a [known issue in 2020.1 editors](https://issuetracker.unity3d.com/issues/wild-memory-leaks-leading-to-stackallocator-walkallocations-crashes). Users can remedy this issue by closing and reopening the editor.
+
 ### Added
 
 Added Randomizers and RandomizerTags

--- a/com.unity.perception/Documentation~/Tutorial/Phase1.md
+++ b/com.unity.perception/Documentation~/Tutorial/Phase1.md
@@ -16,7 +16,7 @@ Steps included this phase of the tutorial:
 
 
 ### <a name="step-1">Step 1: Download Unity Editor and Create a New Project</a> 
-* **Action**: Navigate to [this](https://unity3d.com/get-unity/download/archive) page to download and install the latest version of Unity Editor 2019.4.x. (The tutorial has not yet been fully tested on newer versions.)
+* **Action**: Navigate to [this](https://unity3d.com/get-unity/download/archive) page to download and install the latest version of **Unity Editor 2019.4.x**. (The tutorial has not yet been fully tested on newer versions.)
 
 An alternative approach is to first install [_**Unity Hub**_](https://unity3d.com/get-unity/download), which will allow you to have multiple versions of Unity on your computer, and make it easier to manage your Unity projects and the versions of Unity they will use. 
 

--- a/com.unity.perception/Documentation~/Tutorial/Phase1.md
+++ b/com.unity.perception/Documentation~/Tutorial/Phase1.md
@@ -16,7 +16,7 @@ Steps included this phase of the tutorial:
 
 
 ### <a name="step-1">Step 1: Download Unity Editor and Create a New Project</a> 
-* **Action**: Navigate to [this](https://unity3d.com/get-unity/download/archive) page to download and install the latest version of Unity Editor 2020.1.x. (The tutorial has not yet been tested on newer versions.)
+* **Action**: Navigate to [this](https://unity3d.com/get-unity/download/archive) page to download and install the latest version of Unity Editor 2019.4.x. (The tutorial has not yet been fully tested on newer versions.)
 
 An alternative approach is to first install [_**Unity Hub**_](https://unity3d.com/get-unity/download), which will allow you to have multiple versions of Unity on your computer, and make it easier to manage your Unity projects and the versions of Unity they will use. 
 

--- a/com.unity.perception/Tests/Editor/DatasetCaptureEditorTests.cs
+++ b/com.unity.perception/Tests/Editor/DatasetCaptureEditorTests.cs
@@ -33,6 +33,7 @@ namespace GroundTruthTests
         public IEnumerator SimpleData_GeneratesFullDataset_OnExitPlaymode()
         {
             yield return new EnterPlayMode();
+            DatasetCapture.ResetSimulation();
             var ego = DatasetCapture.RegisterEgo("ego");
             var sensor = DatasetCapture.RegisterSensor(ego, "camera", "", 0.1f, 0);
             sensor.ReportCapture("file.txt", new SensorSpatialData());


### PR DESCRIPTION
# Peer Review Information:
- Disabled 2020.1 tests for this release
- Reset simulation state at the beginning of the SimpleData_GeneratesFullDataset_OnExitPlaymode test to prevent upstream tests from affecting the outcome
