### PR TITLE
USim scenario iteration offset fix

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+USimScenario now correctly deserializes app-params before offsetting the current scenario iteration when executing on Unity Simulation
+
 ## [0.5.0-preview.1] - 2020-10-14
 
 ### Known Issues

--- a/com.unity.perception/Runtime/Randomization/Scenarios/USimScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/USimScenario.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Unity.Simulation;
 
 namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
 {
@@ -14,14 +15,6 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
         public sealed override bool isScenarioComplete => currentIteration >= constants.totalIterations;
 
         /// <summary>
-        /// OnAwake is executed directly after this scenario has been registered and initialized
-        /// </summary>
-        protected sealed override void OnAwake()
-        {
-            currentIteration = constants.instanceIndex;
-        }
-
-        /// <summary>
         /// Progresses the current scenario iteration
         /// </summary>
         protected sealed override void IncrementIteration()
@@ -34,10 +27,11 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
         /// </summary>
         public sealed override void Deserialize()
         {
-            if (string.IsNullOrEmpty(Unity.Simulation.Configuration.Instance.SimulationConfig.app_param_uri))
-                base.Deserialize();
+            if (Configuration.Instance.IsSimulationRunningInCloud())
+                constants = Configuration.Instance.GetAppParams<T>();
             else
-                constants = Unity.Simulation.Configuration.Instance.GetAppParams<T>();
+                base.Deserialize();
+            currentIteration = constants.instanceIndex;
         }
     }
 


### PR DESCRIPTION
# Peer Review Information:
This PR patches a bug in the USimScenario class that resulted in the scenario iteration incorrectly being offset before the Unity Simulation app-params had a chance to deserialize.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated docs
- [X] - Updated changelog
