### PR TITLE
Categorical parameter enumeration fix

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -21,6 +21,8 @@ USimScenario now correctly deserializes app-params before offsetting the current
 
 Fixed Unity Simulation nodes generating one extra empty image before generating their share of the randomization scenario iterations
 
+Fixed enumeration in the CategoricalParameter.categories property
+
 ## [0.5.0-preview.1] - 2020-10-14
 
 ### Known Issues

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
@@ -84,7 +84,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Parameters
             get
             {
                 var catOptions = new List<(T, float)>(m_Categories.Count);
-                for (var i = 0; i < catOptions.Count; i++)
+                for (var i = 0; i < m_Categories.Count; i++)
                     catOptions.Add((m_Categories[i], probabilities[i]));
                 return catOptions;
             }


### PR DESCRIPTION
# Peer Review Information:
Fixed enumeration in the CategoricalParameter.categories property

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
