### PR TITLE
Fixed Unity Simulation nodes generating an empty first image

### DIFF
--- a/.yamato/environments.yml
+++ b/.yamato/environments.yml
@@ -29,7 +29,7 @@ publish_platforms:
     standalone-platform: StandaloneOSX
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:latest
+    image: package-ci/ubuntu:stable
     flavor: b1.large
 
 

--- a/.yamato/promote.yml
+++ b/.yamato/promote.yml
@@ -14,7 +14,7 @@ promotion_test_{{ platform.name }}_{{ editor.version }}:
     UPMCI_PROMOTION: 1
   commands:
     - git submodule update --init --recursive
-    - npm install upm-ci-utils -g --registry {{ upmci_registry }}
+    - npm install upm-ci-utils@stable -g --registry {{ upmci_registry }}
     - upm-ci package test -u {{ editor.version }} --package-path ./com.unity.perception --type vetting-tests
   artifacts:
     logs:

--- a/.yamato/upm-ci-full.yml
+++ b/.yamato/upm-ci-full.yml
@@ -10,7 +10,7 @@ pack_{{ variant.name }}:
     flavor: b1.large
   commands:
      - git submodule update --init --recursive
-     - npm install upm-ci-tools@stable -g --registry {{ upmci_registry }}
+     - npm install upm-ci-utils -g --registry {{ upmci_registry }}
      - upm-ci package pack --package-path ./com.unity.perception/
   artifacts:
     packages:
@@ -29,7 +29,7 @@ pkg_test_{{variant.name}}_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - git submodule update --init --recursive
-    - npm install upm-ci-tools@stable -g --registry {{ upmci_registry }}
+    - npm install upm-ci-utils -g --registry {{ upmci_registry }}
     - upm-ci package test -u {{ editor.version }} --package-path ./com.unity.perception --type vetting-tests
   artifacts:
     logs:

--- a/.yamato/upm-ci-full.yml
+++ b/.yamato/upm-ci-full.yml
@@ -10,7 +10,7 @@ pack_{{ variant.name }}:
     flavor: b1.large
   commands:
      - git submodule update --init --recursive
-     - npm install upm-ci-utils -g --registry https://artifactory.prd.cds.internal.unity3d.com/artifactory/api/npm/upm-npm
+     - npm install upm-ci-tools@stable -g --registry {{ upmci_registry }}
      - upm-ci package pack --package-path ./com.unity.perception/
   artifacts:
     packages:
@@ -29,7 +29,7 @@ pkg_test_{{variant.name}}_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - git submodule update --init --recursive
-    - npm install upm-ci-utils -g --registry {{ upmci_registry }}
+    - npm install upm-ci-tools@stable -g --registry {{ upmci_registry }}
     - upm-ci package test -u {{ editor.version }} --package-path ./com.unity.perception --type vetting-tests
   artifacts:
     logs:

--- a/.yamato/upm-ci-full.yml
+++ b/.yamato/upm-ci-full.yml
@@ -10,7 +10,7 @@ pack_{{ variant.name }}:
     flavor: b1.large
   commands:
      - git submodule update --init --recursive
-     - npm install upm-ci-utils -g --registry {{ upmci_registry }}
+     - npm install upm-ci-utils@stable -g --registry {{ upmci_registry }}
      - upm-ci package pack --package-path ./com.unity.perception/
   artifacts:
     packages:
@@ -29,7 +29,7 @@ pkg_test_{{variant.name}}_{{ platform.name }}_{{ editor.version }}:
     flavor: {{ platform.flavor}}
   commands:
     - git submodule update --init --recursive
-    - npm install upm-ci-utils -g --registry {{ upmci_registry }}
+    - npm install upm-ci-utils@stable -g --registry {{ upmci_registry }}
     - upm-ci package test -u {{ editor.version }} --package-path ./com.unity.perception --type vetting-tests
   artifacts:
     logs:

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 USimScenario now correctly deserializes app-params before offsetting the current scenario iteration when executing on Unity Simulation
 
+Fixed Unity Simulation nodes generating one extra empty image before generating their share of the randomization scenario iterations
+
 ## [0.5.0-preview.1] - 2020-10-14
 
 ### Known Issues

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -136,6 +136,10 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
             foreach (var randomizer in m_Randomizers)
                 randomizer.Create();
             ValidateParameters();
+
+            // Don't skip the first frame if executing on Unity Simulation
+            if (Configuration.Instance.IsSimulationRunningInCloud())
+                m_SkipFrame = false;
         }
 
         void OnEnable()


### PR DESCRIPTION
# Peer Review Information:
In the unity editor and local players, the perception package cannot output the first frame of the simulation, so the randomization scenario class will skip the first frame. This is not the case on Unity Simulation. This PR introduces a check that will allow randomized perception projects to not skip the first frame if running on Unity Simulation.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
