### PR TITLE
Uniform and normal samplers now serialize their random seeds

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -14,6 +14,8 @@ Added support for labeling Terrain objects. Trees and details are not labeled bu
 
 Expanded all Unity Simulation references from USim to Unity Simulation
 
+Uniform and Normal samplers now serialize their random seeds
+
 ### Deprecated
 
 ### Removed

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
@@ -11,7 +11,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
     [Serializable]
     public struct NormalSampler : ISampler
     {
-        Unity.Mathematics.Random m_Random;
+        [SerializeField, HideInInspector] Unity.Mathematics.Random m_Random;
 
         /// <summary>
         /// The mean of the normal distribution to sample from
@@ -26,8 +26,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
         /// <summary>
         /// The base seed used to initialize this sampler's state
         /// </summary>
-        [field: SerializeField]
-        public uint baseSeed { get; set; }
+        [field: SerializeField] public uint baseSeed { get; set; }
 
         /// <summary>
         /// The current random state of this sampler

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
@@ -11,13 +11,12 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
     [Serializable]
     public struct UniformSampler : ISampler
     {
-        Unity.Mathematics.Random m_Random;
+        [SerializeField, HideInInspector] Unity.Mathematics.Random m_Random;
 
         /// <summary>
         /// The base seed used to initialize this sampler's state
         /// </summary>
-        [field: SerializeField]
-        public uint baseSeed { get; set; }
+        [field: SerializeField] public uint baseSeed { get; set; }
 
         /// <summary>
         /// The current random state of this sampler


### PR DESCRIPTION
# Peer Review Information:
Uniform and normal samplers will now serialize their random seeds. This is to prevent Unity's serialization tools from zeroing out the sampler's random state in the editor. This change will allow users to utilize samplers from Edit Mode without the Unity.Mathematics.Random struct within the sampler from throwing an error for having a zeroed out initial state.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
