### PR TITLE
Fixed GenerateRandomSeedFromIndex method

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -26,6 +26,8 @@ Fixed Unity Simulation nodes generating one extra empty image before generating 
 
 Fixed enumeration in the CategoricalParameter.categories property
 
+The GenerateRandomSeedFromIndex method now correctly hashes the current scenario iteration into the random seed it generates
+
 ## [0.5.0-preview.1] - 2020-10-14
 
 ### Known Issues

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -16,6 +16,8 @@ Expanded all Unity Simulation references from USim to Unity Simulation
 
 Uniform and Normal samplers now serialize their random seeds
 
+The ScenarioBase's GenerateIterativeRandomSeed() method has been renamed to GenerateRandomSeedFromIndex()
+
 ### Deprecated
 
 ### Removed

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
@@ -49,7 +49,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
 
             for (var i = 0; i < layerCount; i++)
             {
-                var seed = scenario.GenerateIterativeRandomSeed(i);
+                var seed = scenario.GenerateRandomSeedFromIndex(i);
                 var placementSamples = PoissonDiskSampling.GenerateSamples(
                     placementArea.x, placementArea.y, separationDistance, seed);
                 var offset = new Vector3(placementArea.x, placementArea.y, 0f) * -0.5f;

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -338,15 +338,17 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
         }
 
         /// <summary>
-        /// Generates a random seed by hashing three values together: an arbitrary iteration value,
-        /// the current scenario iteration, and a base random seed
+        /// Generates a random seed by hashing three values together: an arbitrary index value,
+        /// the current scenario iteration, and a base random seed. This method is useful for deterministically
+        /// generating random seeds from within a for-loop.
         /// </summary>
         /// <param name="iteration">An offset value hashed inside the seed generator</param>
         /// <param name="baseSeed">An offset value hashed inside the seed generator</param>
         /// <returns>The generated random seed</returns>
-        public uint GenerateIterativeRandomSeed(int iteration, uint baseSeed = SamplerUtility.largePrime)
+        public uint GenerateRandomSeedFromIndex(int iteration, uint baseSeed = SamplerUtility.largePrime)
         {
-            return SamplerUtility.IterateSeed((uint)iteration, baseSeed);
+            var seed =  SamplerUtility.IterateSeed((uint)iteration, baseSeed);
+            return SamplerUtility.IterateSeed((uint)currentIteration, seed);
         }
 
         void ValidateParameters()

--- a/com.unity.perception/Tests/Runtime/Randomization/ScenarioTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ScenarioTests.cs
@@ -118,6 +118,21 @@ namespace RandomizationTests
             Assert.AreEqual(DatasetCapture.SimulationState.SequenceTime, 0);
         }
 
+        [UnityTest]
+        public IEnumerator GeneratedRandomSeedsChangeWithScenarioIteration()
+        {
+            yield return CreateNewScenario(3, 1);
+            var seed = m_Scenario.GenerateRandomSeed();
+            var seeds = new uint[3];
+            for (var i = 0; i < 3; i++)
+                seeds[i] = m_Scenario.GenerateRandomSeedFromIndex(i);
+
+            yield return null;
+            Assert.AreNotEqual(seed, m_Scenario.GenerateRandomSeed());
+            for (var i = 0; i < 3; i++)
+                Assert.AreNotEqual(seeds[i], m_Scenario.GenerateRandomSeedFromIndex(i));
+        }
+
         PerceptionCamera SetupPerceptionCamera()
         {
             m_TestObject.SetActive(false);


### PR DESCRIPTION
# Peer Review Information:
ScenarioBase's GenerateRandomSeedFromIndex() method now correctly hashes the current scenario iteration into the generated random seed.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
