### PR TITLE
Report annotation result fix il2cpp

### DIFF
--- a/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
@@ -52,7 +52,7 @@ namespace UnityEngine.Perception.GroundTruth
         string m_OutputDirectoryPath;
 
         JsonSerializer m_AnnotationSerializer;
-        
+
         public bool IsRunning { get; private set; }
 
         public string OutputDirectory
@@ -77,7 +77,7 @@ namespace UnityEngine.Perception.GroundTruth
             m_AnnotationSerializer = JsonSerializer.CreateDefault();
             m_AnnotationSerializer.Converters.Add(new Vector3Converter());
             m_AnnotationSerializer.Converters.Add(new QuaternionConverter());
-            
+
             m_OutputDirectoryName = outputDirectory;
             IsRunning = true;
         }
@@ -639,7 +639,7 @@ namespace UnityEngine.Perception.GroundTruth
             {
                 var q = Quaternion.identity;
                 reader.Read(); // open [ token
-                q.x = (float)reader.ReadAsDecimal(); 
+                q.x = (float)reader.ReadAsDecimal();
                 q.y = (float)reader.ReadAsDecimal();
                 q.z = (float)reader.ReadAsDecimal();
                 q.w = (float)reader.ReadAsDecimal();
@@ -647,8 +647,8 @@ namespace UnityEngine.Perception.GroundTruth
                 return q;
             }
         }
-        
-        
+
+
         [SuppressMessage("ReSharper", "PossibleInvalidOperationException")]
         public class Vector3Converter : JsonConverter<Vector3>
         {
@@ -672,11 +672,21 @@ namespace UnityEngine.Perception.GroundTruth
                 return outVector;
             }
         }
-        
+
         public void ReportAsyncAnnotationResult<T>(AsyncAnnotation asyncAnnotation, string filename = null, IEnumerable<T> values = null)
         {
-            var jArray = values == null ? null : JArray.FromObject(values, m_AnnotationSerializer);
-            
+            JArray jArray = null;
+
+            if (values != null)
+            {
+                jArray = new JArray();
+                foreach (var value in values)
+                {
+                    if (value != null)
+                        jArray.Add(new JRaw(DatasetJsonUtility.ToJToken(value)));
+                }
+            }
+
             ReportAsyncAnnotationResult<T>(asyncAnnotation, filename, jArray);
         }
 

--- a/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
@@ -77,7 +77,6 @@ namespace UnityEngine.Perception.GroundTruth
             m_AnnotationSerializer = JsonSerializer.CreateDefault();
             m_AnnotationSerializer.Converters.Add(new Vector3Converter());
             m_AnnotationSerializer.Converters.Add(new QuaternionConverter());
-
             m_OutputDirectoryName = outputDirectory;
             IsRunning = true;
         }
@@ -647,8 +646,6 @@ namespace UnityEngine.Perception.GroundTruth
                 return q;
             }
         }
-
-
         [SuppressMessage("ReSharper", "PossibleInvalidOperationException")]
         public class Vector3Converter : JsonConverter<Vector3>
         {
@@ -672,7 +669,6 @@ namespace UnityEngine.Perception.GroundTruth
                 return outVector;
             }
         }
-
         public void ReportAsyncAnnotationResult<T>(AsyncAnnotation asyncAnnotation, string filename = null, IEnumerable<T> values = null)
         {
             JArray jArray = null;

--- a/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
@@ -52,7 +52,6 @@ namespace UnityEngine.Perception.GroundTruth
         string m_OutputDirectoryPath;
 
         JsonSerializer m_AnnotationSerializer;
-
         public bool IsRunning { get; private set; }
 
         public string OutputDirectory

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/DatasetCaptureTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/DatasetCaptureTests.cs
@@ -447,13 +447,13 @@ namespace GroundTruthTests
           ""annotation_definition"": <guid>,
           ""values"": [
             {{
-              ""a"": ""a string"",
-              ""b"": 10
-            }},
+  ""a"": ""a string"",
+  ""b"": 10
+}},
             {{
-              ""a"": ""a second string"",
-              ""b"": 20
-            }}
+  ""a"": ""a second string"",
+  ""b"": 20
+}}
           ]
         }}
       ]";

--- a/com.unity.perception/package.json
+++ b/com.unity.perception/package.json
@@ -2,6 +2,7 @@
   "dependencies": {
     "com.unity.nuget.newtonsoft-json": "1.1.2",
     "com.unity.render-pipelines.core": "7.1.6",
+    "com.unity.burst": "1.3.9",
     "com.unity.entities": "0.8.0-preview.8",
     "com.unity.simulation.client": "0.0.10-preview.9",
     "com.unity.simulation.capture": "0.0.10-preview.13",


### PR DESCRIPTION
# Peer Review Information:
Newtonsoft JArray.FromObject(values, m_AnnotationSerializer) API call uses LINQ under the hood which is not supported on IL2CPP. It throws an exception at runtime.
Replacing this API call with using DatasetJsonUtility instead.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing: Was reproducible on usim with cloudrendering build target and the regular standalone player with il2cpp scripting backend.
Manually verified the fix on cloud rendering buidltarget 
**Tests Added**: 

**Core Scenario Tested**: Boundingbox annotation report serialization at the end of the simulation run.

**At Risk Areas**: Boudingbox annotation reporting.

**Notes + Expectations**: Bounding annotation reporting should work with IL2CPP scripting backend on all platforms.