### PR TITLE
Removed corrupted meta files

### DIFF
--- a/.yamato/environments.yml
+++ b/.yamato/environments.yml
@@ -8,11 +8,11 @@ coverage_editors:
 
 per_commit_editors:
   - version: 2019.4.6f1
-  - version: 2020.1.14f1
+  - version: 2020.1.15f1
 
 complete_editors:
   - version: 2019.4.6f1
-  - version: 2020.1.14f1
+  - version: 2020.1.15f1
 #  - version: 2020.2.0a21
 
 publish_platforms:

--- a/.yamato/environments.yml
+++ b/.yamato/environments.yml
@@ -11,7 +11,7 @@ per_commit_editors:
 
 complete_editors:
   - version: 2019.4.6f1
-#  - version: 2020.1.3f1
+  - version: 2020.1.14f1
 #  - version: 2020.2.0a21
 
 publish_platforms:

--- a/.yamato/environments.yml
+++ b/.yamato/environments.yml
@@ -8,6 +8,7 @@ coverage_editors:
 
 per_commit_editors:
   - version: 2019.4.6f1
+  - version: 2020.1.14f1
 
 complete_editors:
   - version: 2019.4.6f1

--- a/.yamato/environments.yml
+++ b/.yamato/environments.yml
@@ -8,11 +8,11 @@ coverage_editors:
 
 per_commit_editors:
   - version: 2019.4.6f1
-  - version: 2020.1.15f1
+#  - version: 2020.1.15f1
 
 complete_editors:
   - version: 2019.4.6f1
-  - version: 2020.1.15f1
+#  - version: 2020.1.15f1
 #  - version: 2020.2.0a21
 
 publish_platforms:

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -35,6 +35,8 @@ Fixed enumeration in the CategoricalParameter.categories property
 
 The GenerateRandomSeedFromIndex method now correctly hashes the current scenario iteration into the random seed it generates
 
+Corrupted .meta files have been rebuilt and replaced
+
 ## [0.5.0-preview.1] - 2020-10-14
 
 ### Known Issues

--- a/com.unity.perception/Editor/Randomization/Editors.meta
+++ b/com.unity.perception/Editor/Randomization/Editors.meta
@@ -1,8 +1,8 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 85401640505a48f9a8fe55045f5f28d8
-timeCreated: 1600754567
-=======
-guid: 0b17046409af4c22bf74eec2a5965984
-timeCreated: 1598135707
->>>>>>> 86d25d2... implemented parameter behaviours
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/Editors/ScenarioBaseEditor.cs.meta
+++ b/com.unity.perception/Editor/Randomization/Editors/ScenarioBaseEditor.cs.meta
@@ -1,8 +1,11 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 57a29c3831024d55aca1a6267dabb56c
-timeCreated: 1600754583
-=======
-guid: face5e97e23d402cbf6fafadb39fa0c3
-timeCreated: 1596213301
->>>>>>> 86d25d2... implemented parameter behaviours
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/PropertyDrawers.meta
+++ b/com.unity.perception/Editor/Randomization/PropertyDrawers.meta
@@ -1,8 +1,8 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 47a26876f92a4b19adb3b7b525efa830
-timeCreated: 1600754588
-=======
-guid: d3107e026b2943c1868c9b3f8c6480d3
-timeCreated: 1598135730
->>>>>>> 86d25d2... implemented parameter behaviours
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/PropertyDrawers/ColorHsvaDrawer.cs.meta
+++ b/com.unity.perception/Editor/Randomization/PropertyDrawers/ColorHsvaDrawer.cs.meta
@@ -1,8 +1,11 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: e2ea91ddb1134cc6a14d2e3859a275f5
-timeCreated: 1600754588
-=======
-guid: 5e8094c28dd142a09fbbd38ca560164b
-timeCreated: 1598250942
->>>>>>> 86d25d2... implemented parameter behaviours
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/PropertyDrawers/ParameterDrawer.cs.meta
+++ b/com.unity.perception/Editor/Randomization/PropertyDrawers/ParameterDrawer.cs.meta
@@ -1,8 +1,11 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: e396dea59a4843529416020c3d0ef5af
-timeCreated: 1600754588
-=======
-guid: d389620d3aa3471ca1877eb59cdfb465
-timeCreated: 1598135745
->>>>>>> 86d25d2... implemented parameter behaviours
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/StaticData.cs.meta
+++ b/com.unity.perception/Editor/Randomization/StaticData.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 63e6a339ad0c4a2e8d110f120397a17b
-timeCreated: 1595278931
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/Uss.meta
+++ b/com.unity.perception/Editor/Randomization/Uss.meta
@@ -1,3 +1,8 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: fcf9d543882d491e9b2c1e9a32f18763
-timeCreated: 1590479034
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/Uxml.meta
+++ b/com.unity.perception/Editor/Randomization/Uxml.meta
@@ -1,3 +1,8 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 36c3e81fb3034cce8b3f05ceac6bae70
-timeCreated: 1590479019
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/Uxml/Parameter/ParameterDrawer.uxml.meta
+++ b/com.unity.perception/Editor/Randomization/Uxml/Parameter/ParameterDrawer.uxml.meta
@@ -1,8 +1,10 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: fbfd6bfda79247c1a4578907f9df9d6c
-timeCreated: 1600754588
-=======
-guid: 6a4bb3efae29429292ccdfa63e661872
-timeCreated: 1598240583
->>>>>>> 86d25d2... implemented parameter behaviours
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 13804, guid: 0000000000000000e000000000000000, type: 0}

--- a/com.unity.perception/Editor/Randomization/VisualElements.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements.meta
@@ -1,8 +1,8 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 64930d74a0b54875ab472b72066417bc
-timeCreated: 1600754567
-=======
-guid: 7f8f95a1bb144a96b9310164f5560387
-timeCreated: 1598135666
->>>>>>> 86d25d2... implemented parameter behaviours
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter.meta
@@ -1,3 +1,8 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 198e373f78464aa7a4bf4211e82434dc
-timeCreated: 1601669088
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter/CategoricalOptionElement.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter/CategoricalOptionElement.cs.meta
@@ -1,8 +1,11 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 5b6d309152934df99cfff89a96b9703e
-timeCreated: 1600754567
-=======
-guid: 3066f77d411047baafb6cc454adc6e37
-timeCreated: 1595535184
->>>>>>> 86d25d2... implemented parameter behaviours
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter/ColorHsvaField.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter/ColorHsvaField.cs.meta
@@ -1,8 +1,11 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: c70590a385e44f6fbe82f5c74cb92f71
-timeCreated: 1600754567
-=======
-guid: 103b163a2467415ab86b0df8175b12a6
-timeCreated: 1598254290
->>>>>>> 86d25d2... implemented parameter behaviours
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter/DrawerParameterElement.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter/DrawerParameterElement.cs.meta
@@ -1,8 +1,11 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: a9f0d234cfc24a8da54ec04d5ec9a129
-timeCreated: 1600754567
-=======
-guid: e2eb905ca8c14b5cbe43e48418948be0
-timeCreated: 1598255728
->>>>>>> 86d25d2... implemented parameter behaviours
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter/ParameterElement.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter/ParameterElement.cs.meta
@@ -1,8 +1,11 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: b15caa7425ab4b9a8367bd544ab4730d
-timeCreated: 1600754567
-=======
-guid: ea72d77c64d1447aa195e2068f02cf74
-timeCreated: 1595279847
->>>>>>> 86d25d2... implemented parameter behaviours
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer.meta
@@ -1,3 +1,8 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: c194e9893fcc4197ab26d01371347d07
-timeCreated: 1601054944
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/AddRandomizerMenu.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/AddRandomizerMenu.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 26546e1877734ec5bd9d40a36eaa5322
-timeCreated: 1600836688
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerElement.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerElement.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: b06477660dbb47749bbc3db0aeb5005d
-timeCreated: 1600290125
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerList.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerList.cs.meta
@@ -1,3 +1,11 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: dcef5294bac746bbad269c94b529f7df
-timeCreated: 1600366159
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerReorderingIndicator.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerReorderingIndicator.cs.meta
@@ -1,15 +1,5 @@
-<<<<<<< HEAD
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
-guid: 61021c66c33e40e98de0702ae0aa4449
-timeCreated: 1600754567
-=======
-guid: 7c1e08b02e5a4c55875f34baf32f8e76
-timeCreated: 1596143672
->>>>>>> 86d25d2... implemented parameter behaviours
-=======
 fileFormatVersion: 2
-guid: 7c1e08b02e5a4c55875f34baf32f8e76
+guid: e43353090a445024ab8110b73630525a
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2
@@ -19,4 +9,3 @@ MonoImporter:
   userData: 
   assetBundleName: 
   assetBundleVariant: 
->>>>>>> 750f255... working on new workflow

--- a/com.unity.perception/Editor/Randomization/VisualElements/Sampler.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Sampler.meta
@@ -1,3 +1,8 @@
-﻿fileFormatVersion: 2
+fileFormatVersion: 2
 guid: 650bdb8ee9ab42f99509974c7a076e00
-timeCreated: 1601669132
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Sampler/FloatRangeElement.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Sampler/FloatRangeElement.cs.meta
@@ -1,8 +1,11 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 708f941b18c345d8a0b7d1ea31d27843
-timeCreated: 1600754567
-=======
-guid: e37f169c618d471d8ed9614a41096437
-timeCreated: 1595281335
->>>>>>> 86d25d2... implemented parameter behaviours
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Sampler/RandomSeedField.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Sampler/RandomSeedField.cs.meta
@@ -1,8 +1,11 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 7df00c41d9394fa0ae239349350cb563
-timeCreated: 1600754567
-=======
-guid: b4fa54f5ed5d4d67a278fa8b42dc55cb
-timeCreated: 1596171029
->>>>>>> 86d25d2... implemented parameter behaviours
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Sampler/SamplerElement.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Sampler/SamplerElement.cs.meta
@@ -1,8 +1,11 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 134b50014b9f4c0694a087d3529ea4c2
-timeCreated: 1600754567
-=======
-guid: b367f8f2cb8e465ca2d60ccbd5414a14
-timeCreated: 1595277943
->>>>>>> 86d25d2... implemented parameter behaviours
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters.meta
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters.meta
@@ -1,8 +1,8 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 2b14f5553d2847319c3077ecf7206d06
-timeCreated: 1600754588
-=======
-guid: ce91e289cdaa4ccc849a0c287aefd34d
-timeCreated: 1598326361
->>>>>>> 50f2c39... Added xml documentation
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Runtime/Randomization/Randomizers.meta
+++ b/com.unity.perception/Runtime/Randomization/Randomizers.meta
@@ -1,8 +1,8 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 80645bae9cd440ca81c7a1e03572e7da
-timeCreated: 1600754588
-=======
-guid: ae6aad06c0e14f67aa7a9ad9004a1828
-timeCreated: 1600274594
->>>>>>> c653d18... Implemented randomizer class. Ran into SerializeReference issue 1193322.
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests.meta
+++ b/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests.meta
@@ -1,8 +1,8 @@
-﻿fileFormatVersion: 2
-<<<<<<< HEAD
+fileFormatVersion: 2
 guid: 6693ffffff2148b0a248e1d8c5ddc805
-timeCreated: 1600754588
-=======
-guid: f9e02c502b7845229d26d377a0d871f1
-timeCreated: 1600744200
->>>>>>> cb407fb... added randomizer tests
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Peer Review Information:
Many .meta files seemingly in the middle of merge conflicts have been identified within the perception package and rebuilt. This process has fixed the supposed memory leak bug previously encountered when adding the perception package to a 2020.1 project.

This PR will also reenable Unity 2020.1 per commit tests.

## Editor / Package versioning:
**Editor Version Target**: 2019.4 and 2020.1

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
