### PR TITLE
Added undo callback to refresh randomizer list UI

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -37,6 +37,8 @@ The GenerateRandomSeedFromIndex method now correctly hashes the current scenario
 
 Corrupted .meta files have been rebuilt and replaced
 
+The randomizer list inspector UI now updates appropriately when a user clicks undo
+
 ## [0.5.0-preview.1] - 2020-10-14
 
 ### Known Issues


### PR DESCRIPTION
# Peer Review Information:
The randomizer list inspector UI now updates appropriately when a user clicks undo.

## Editor / Package versioning:
**Editor Version Target**: 2019.34

## Checklist
- [X] - Updated changelog
