### PR TITLE
Fixed overlay panel bug

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+Fixed an issue where the overlay panel would display a full screen semi-transparent image over the entire screen when the overlay panel is disabled in the UI
+
 ## [0.6.0-preview.1] - 2020-12-03
 
 ### Added

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/Visualization/OverlayPanel.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/Visualization/OverlayPanel.cs
@@ -68,6 +68,8 @@ namespace UnityEngine.Perception.GroundTruth
                 }
             }
 
+            m_OverlayImage.enabled = isEnabled;
+
             // Clear out the handle to the cached overlay texture if we are not isEnabled
             if (!isEnabled)
                 m_OverlayImage.texture = null;


### PR DESCRIPTION
Fixed an issue where the overlay panel would display a full screen semi-transparent image over the entire screen when the overlay panel is disabled in the UI

# Peer Review Information:
Information on any code, feature, documentation changes here

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ x] - Updated docs
- [ x] - Updated changelog
