### PR TITLE
Randomizer tag inheritence

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -13,6 +13,8 @@ Added ScenarioConstants base class for all scenario constants objects
 
 Added ScenarioBase.SerializeToConfigFile()
 
+Randomizer tags now support inheritance
+
 ### Changed
 
 Randomizers now access their parent scenario through the static activeScenario property

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
@@ -97,6 +97,8 @@ namespace UnityEngine.Experimental.Perception.Randomization.Parameters
         public override void Validate()
         {
             base.Validate();
+            if (m_Categories.Count == 0)
+                throw new ParameterValidationException("No options added to categorical parameter");
             if (!uniform)
             {
                 if (probabilities.Count != m_Categories.Count)

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterValidationException.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterValidationException.cs
@@ -5,5 +5,6 @@ namespace UnityEngine.Experimental.Perception.Randomization.Parameters
     class ParameterValidationException : Exception
     {
         public ParameterValidationException(string msg) : base(msg) {}
+        public ParameterValidationException(string msg, Exception innerException) : base(msg, innerException) {}
     }
 }

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
@@ -9,33 +9,90 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
     /// </summary>
     public class RandomizerTagManager
     {
+        Dictionary<Type, List<Type>> m_TypeCache = new Dictionary<Type, List<Type>>();
         Dictionary<Type, HashSet<GameObject>> m_TagMap = new Dictionary<Type, HashSet<GameObject>>();
+        Dictionary<GameObject, HashSet<Type>> m_ObjectTags = new Dictionary<GameObject, HashSet<Type>>();
 
         /// <summary>
         /// Enumerates all GameObjects in the scene that have a RandomizerTag of the given type
         /// </summary>
         /// <typeparam name="T">The type of RandomizerTag to query for</typeparam>
+        /// <param name="returnSubclasses">Should this method retrieve all tags derived from the passed in tag also?</param>
         /// <returns>GameObjects with the given RandomizerTag</returns>
-        public IEnumerable<GameObject> Query<T>() where T : RandomizerTag
+        public IEnumerable<GameObject> Query<T>(bool returnSubclasses = false) where T : RandomizerTag
         {
             var type = typeof(T);
+
             if (!m_TagMap.ContainsKey(type))
                 yield break;
+
             foreach (var taggedObject in m_TagMap[type])
-                yield return taggedObject;
+            {
+                if (returnSubclasses)
+                {
+                    yield return taggedObject.gameObject;
+                }
+                else
+                {
+                    if (m_ObjectTags.ContainsKey(taggedObject) && m_ObjectTags[taggedObject].Contains(type))
+                        yield return taggedObject.gameObject;
+                }
+            }
         }
 
         internal void AddTag(Type tagType, GameObject obj)
         {
-            if (!m_TagMap.ContainsKey(tagType))
-                m_TagMap[tagType] = new HashSet<GameObject>();
-            m_TagMap[tagType].Add(obj);
+            // Add tag to the game object to tag map
+            if (!m_ObjectTags.ContainsKey(obj))
+                m_ObjectTags[obj] = new HashSet<Type>();
+
+            m_ObjectTags[obj].Add(tagType);
+
+            if (!m_TypeCache.ContainsKey(tagType))
+            {
+                var inheritedTags = new List<Type>();
+
+                while (tagType != null && tagType != typeof(RandomizerTag))
+                {
+                    inheritedTags.Add(tagType);
+                    tagType = tagType.BaseType;
+                }
+
+                m_TypeCache[tagType] = inheritedTags;
+            }
+
+            var tags = m_TypeCache[tagType];
+
+            foreach (var tag in tags)
+            {
+                if (!m_TagMap.ContainsKey(tag))
+                    m_TagMap[tag] = new HashSet<GameObject>();
+                m_TagMap[tag].Add(obj);
+            }
         }
 
         internal void RemoveTag(Type tagType, GameObject obj)
         {
-            if (m_TagMap.ContainsKey(tagType))
-                m_TagMap[tagType].Remove(obj);
+            // Grab all of the tags from the inheritance tree, and remove
+            // the passed in object from all of them
+            if (m_TypeCache.ContainsKey(tagType))
+            {
+                var tags = m_TypeCache[tagType];
+
+                foreach (var tag in tags.Where(tag => m_TagMap.ContainsKey(tag)))
+                {
+                    m_TagMap[tag].Remove(obj);
+                }
+            }
+
+            // Remove entry from the object to tag map
+            if (m_ObjectTags.ContainsKey(obj))
+            {
+                m_ObjectTags[obj].Remove(tagType);
+
+                if (!m_ObjectTags[obj].Any())
+                    m_ObjectTags.Remove(obj);
+            }
         }
     }
 }

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
@@ -9,9 +9,8 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
     /// </summary>
     public class RandomizerTagManager
     {
-        Dictionary<Type, List<Type>> m_TypeCache = new Dictionary<Type, List<Type>>();
+        Dictionary<Type, HashSet<Type>> m_TypeCache = new Dictionary<Type, HashSet<Type>>();
         Dictionary<Type, HashSet<GameObject>> m_TagMap = new Dictionary<Type, HashSet<GameObject>>();
-        Dictionary<GameObject, HashSet<Type>> m_ObjectTags = new Dictionary<GameObject, HashSet<Type>>();
 
         /// <summary>
         /// Enumerates all GameObjects in the scene that have a RandomizerTag of the given type
@@ -21,78 +20,50 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
         /// <returns>GameObjects with the given RandomizerTag</returns>
         public IEnumerable<GameObject> Query<T>(bool returnSubclasses = false) where T : RandomizerTag
         {
-            var type = typeof(T);
-
-            if (!m_TagMap.ContainsKey(type))
+            var queriedTagType = typeof(T);
+            if (!m_TagMap.ContainsKey(queriedTagType))
                 yield break;
 
-            foreach (var taggedObject in m_TagMap[type])
+            if (returnSubclasses)
             {
-                if (returnSubclasses)
+                foreach (var tagType in m_TypeCache[queriedTagType])
                 {
+                    foreach (var obj in m_TagMap[tagType])
+                        yield return obj;
+                }
+            }
+            else
+            {
+                foreach (var taggedObject in m_TagMap[queriedTagType])
                     yield return taggedObject.gameObject;
-                }
-                else
-                {
-                    if (m_ObjectTags.ContainsKey(taggedObject) && m_ObjectTags[taggedObject].Contains(type))
-                        yield return taggedObject.gameObject;
-                }
             }
         }
 
         internal void AddTag(Type tagType, GameObject obj)
         {
-            // Add tag to the game object to tag map
-            if (!m_ObjectTags.ContainsKey(obj))
-                m_ObjectTags[obj] = new HashSet<Type>();
-
-            m_ObjectTags[obj].Add(tagType);
-
             if (!m_TypeCache.ContainsKey(tagType))
+                AddTagTypeAndBaseTagTypesToCache(tagType);
+            m_TagMap[tagType].Add(obj);
+        }
+
+        void AddTagTypeAndBaseTagTypesToCache(Type tagType)
+        {
+            var recursiveTagType = tagType;
+            var inheritedTags = new HashSet<Type>();
+            while (recursiveTagType != null && recursiveTagType != typeof(RandomizerTag))
             {
-                var inheritedTags = new List<Type>();
-
-                while (tagType != null && tagType != typeof(RandomizerTag))
-                {
-                    inheritedTags.Add(tagType);
-                    tagType = tagType.BaseType;
-                }
-
-                m_TypeCache[tagType] = inheritedTags;
+                inheritedTags.Add(recursiveTagType);
+                if (!m_TagMap.ContainsKey(recursiveTagType))
+                    m_TagMap[recursiveTagType] = new HashSet<GameObject>();
+                recursiveTagType = recursiveTagType.BaseType;
             }
-
-            var tags = m_TypeCache[tagType];
-
-            foreach (var tag in tags)
-            {
-                if (!m_TagMap.ContainsKey(tag))
-                    m_TagMap[tag] = new HashSet<GameObject>();
-                m_TagMap[tag].Add(obj);
-            }
+            m_TypeCache[tagType] = inheritedTags;
         }
 
         internal void RemoveTag(Type tagType, GameObject obj)
         {
-            // Grab all of the tags from the inheritance tree, and remove
-            // the passed in object from all of them
-            if (m_TypeCache.ContainsKey(tagType))
-            {
-                var tags = m_TypeCache[tagType];
-
-                foreach (var tag in tags.Where(tag => m_TagMap.ContainsKey(tag)))
-                {
-                    m_TagMap[tag].Remove(obj);
-                }
-            }
-
-            // Remove entry from the object to tag map
-            if (m_ObjectTags.ContainsKey(obj))
-            {
-                m_ObjectTags[obj].Remove(tagType);
-
-                if (!m_ObjectTags[obj].Any())
-                    m_ObjectTags.Remove(obj);
-            }
+            if (m_TagMap.ContainsKey(tagType) && m_TagMap[tagType].Contains(obj))
+                m_TagMap[tagType].Remove(obj);
         }
     }
 }

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
@@ -26,6 +26,14 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
         }
 
         /// <summary>
+        /// Constructs a ConstantSampler
+        /// </summary>
+        public ConstantSampler()
+        {
+            value = 0f;
+        }
+
+        /// <summary>
         /// Constructs a new ConstantSampler
         /// </summary>
         /// <param name="value">The value from which samples will be generated</param>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
@@ -32,6 +32,16 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
         /// <summary>
         /// Constructs a normal distribution sampler
         /// </summary>
+        public NormalSampler()
+        {
+            range = new FloatRange(-1f, 1f);
+            mean = 0;
+            standardDeviation = 1;
+        }
+
+        /// <summary>
+        /// Constructs a normal distribution sampler
+        /// </summary>
         /// <param name="min">The smallest value contained within the range</param>
         /// <param name="max">The largest value contained within the range</param>
         /// <param name="mean">The mean of the normal distribution to sample from</param>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
@@ -43,8 +43,9 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
         /// <returns>The generated sample</returns>
         public float Sample()
         {
-            var rng = new Unity.Mathematics.Random(ScenarioBase.activeScenario.NextRandomState());
-            return math.lerp(range.minimum, range.maximum, rng.NextFloat());
+            var newRandomState = ScenarioBase.activeScenario.NextRandomState();
+            var rng = new Unity.Mathematics.Random(newRandomState);
+            return rng.NextFloat(range.minimum, range.maximum);
         }
 
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
@@ -43,8 +43,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
         /// <returns>The generated sample</returns>
         public float Sample()
         {
-            var newRandomState = ScenarioBase.activeScenario.NextRandomState();
-            var rng = new Unity.Mathematics.Random(newRandomState);
+            var rng = new Unity.Mathematics.Random(ScenarioBase.activeScenario.NextRandomState());
             return rng.NextFloat(range.minimum, range.maximum);
         }
 

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
@@ -20,6 +20,14 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
         public FloatRange range { get; set; }
 
         /// <summary>
+        /// Constructs a UniformSampler
+        /// </summary>
+        public UniformSampler()
+        {
+            range = new FloatRange(0f, 1f);
+        }
+
+        /// <summary>
         /// Constructs a new uniform distribution sampler
         /// </summary>
         /// <param name="min">The smallest value contained within the range</param>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
@@ -55,6 +55,18 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
         }
 
         /// <summary>
+        /// Generates a 32-bit non-zero hash using an unsigned integer seed
+        /// </summary>
+        /// <param name="seed">The unsigned integer to hash</param>
+        /// <returns>The calculated hash value</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static uint Hash32NonZero(uint seed)
+        {
+            var hash = Hash32(seed);
+            return hash == 0u ? largePrime : hash;
+        }
+
+        /// <summary>
         /// Based on splitmix64: http://xorshift.di.unimi.it/splitmix64.c
         /// </summary>
         /// <param name="x">64-bit value to hash</param>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -67,7 +67,16 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
         /// </summary>
         public static ScenarioBase activeScenario
         {
-            get => s_ActiveScenario;
+            get
+            {
+#if UNITY_EDITOR
+                // This compiler define is required to allow samplers to
+                // iterate the scenario's random state in edit-mode
+                if (s_ActiveScenario == null)
+                    s_ActiveScenario = FindObjectOfType<ScenarioBase>();
+#endif
+                return s_ActiveScenario;
+            }
             private set
             {
                 if (value != null && s_ActiveScenario != null && value != s_ActiveScenario)
@@ -182,21 +191,6 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
             // Don't skip the first frame if executing on Unity Simulation
             if (Configuration.Instance.IsSimulationRunningInCloud())
                 m_SkipFrame = false;
-        }
-
-        void OnEnable()
-        {
-            activeScenario = this;
-        }
-
-        void OnDisable()
-        {
-            s_ActiveScenario = null;
-        }
-
-        void Reset()
-        {
-            activeScenario = this;
         }
 
         void Start()

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -383,7 +383,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
         /// <returns>The newly generated random state</returns>
         public uint NextRandomState()
         {
-            m_RandomState = SamplerUtility.Hash32(m_RandomState);
+            m_RandomState = SamplerUtility.Hash32NonZero(m_RandomState);
             return m_RandomState;
         }
 

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Unity.Simulation;
 using UnityEngine;
+using UnityEngine.Experimental.Perception.Randomization.Parameters;
 using UnityEngine.Experimental.Perception.Randomization.Randomizers;
 using UnityEngine.Experimental.Perception.Randomization.Samplers;
 using UnityEngine.Perception.GroundTruth;
@@ -391,7 +392,16 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
         {
             foreach (var randomizer in m_Randomizers)
             foreach (var parameter in randomizer.parameters)
-                parameter.Validate();
+            {
+                try
+                {
+                    parameter.Validate();
+                }
+                catch (ParameterValidationException exception)
+                {
+                    Debug.LogException(exception, this);
+                }
+            }
         }
     }
 }

--- a/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/ExampleTag.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/ExampleTag.cs
@@ -3,4 +3,6 @@
 namespace RandomizationTests.RandomizerTests
 {
     public class ExampleTag : RandomizerTag { }
+
+    public class ExampleTag2 : ExampleTag { }
 }

--- a/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/RandomizerTagTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/RandomizerTagTests.cs
@@ -35,8 +35,19 @@ namespace RandomizationTests.RandomizerTests
             for (var i = 0; i < copyCount - 1; i++)
                 Object.Instantiate(gameObject);
 
+            var gameObject2 = new GameObject();
+            gameObject2.AddComponent<ExampleTag2>();
+            for (var i = 0; i < copyCount - 1; i++)
+                Object.Instantiate(gameObject2);
+
             var queriedObjects = m_Scenario.tagManager.Query<ExampleTag>().ToArray();
             Assert.AreEqual(queriedObjects.Length, copyCount);
+
+            queriedObjects = m_Scenario.tagManager.Query<ExampleTag2>().ToArray();
+            Assert.AreEqual(queriedObjects.Length, copyCount);
+
+            queriedObjects = m_Scenario.tagManager.Query<ExampleTag>(true).ToArray();
+            Assert.AreEqual(queriedObjects.Length, copyCount * 2);
         }
     }
 }


### PR DESCRIPTION
# Peer Review Information:
Randomizer tags support inheritance. A user can query tag of a specific type, or of any type that inherits from it.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Added**: 
Modified TagQueryFindsCorrectNumberOfGameObjects test to test that inheritance works properly

## Checklist
- [x] - Updated docs
- [x] - Updated changelog
