### PR TITLE
Fixing crash and memory leak on long simulations

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -37,6 +37,8 @@ Removed ScenarioBase.GenerateRandomSeedFromIndex()
 
 Fixed an issue where the overlay panel would display a full screen semi-transparent image over the entire screen when the overlay panel is disabled in the UI
 Fixed a bug in instance segmentation labeler that erroneously logged that object ID 255 was not supported
+Fixed the simulation stopping while the editor/player is not focused
+Fixed memory leak or crash occurring at the end of long simulations when using BackgroundObjectPlacementRandomizer or ForegroundObjectPlacementRandomizer
 
 ## [0.6.0-preview.1] - 2020-12-03
 

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -36,8 +36,11 @@ Removed ScenarioBase.GenerateRandomSeedFromIndex()
 ### Fixed
 
 Fixed an issue where the overlay panel would display a full screen semi-transparent image over the entire screen when the overlay panel is disabled in the UI
+
 Fixed a bug in instance segmentation labeler that erroneously logged that object ID 255 was not supported
+
 Fixed the simulation stopping while the editor/player is not focused
+
 Fixed memory leak or crash occurring at the end of long simulations when using BackgroundObjectPlacementRandomizer or ForegroundObjectPlacementRandomizer
 
 ## [0.6.0-preview.1] - 2020-12-03

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -129,6 +129,8 @@ namespace UnityEngine.Perception.GroundTruth
             AsyncRequest.maxJobSystemParallelism = 0; // Jobs are not chained to one another in any way, maximizing parallelism
             AsyncRequest.maxAsyncRequestFrameAge = 4; // Ensure that readbacks happen before Allocator.TempJob allocations get stale
 
+            Application.runInBackground = true;
+
             SetupInstanceSegmentation();
             m_AttachedCamera = GetComponent<Camera>();
 

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine.Experimental.Perception.Randomization.Parameters;
 using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
@@ -12,8 +13,6 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
     [AddRandomizerMenu("Perception/Background Object Placement Randomizer")]
     public class BackgroundObjectPlacementRandomizer : Randomizer
     {
-        List<GameObject> m_SpawnedObjects = new List<GameObject>();
-
         /// <summary>
         /// The Z offset component applied to all generated background layers
         /// </summary>
@@ -39,26 +38,31 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
         /// </summary>
         public GameObjectParameter prefabs;
 
+        GameObject container;
+        GameObjectOneWayCache gameObjectOneWayCache;
+
+        protected override void OnCreate()
+        {
+            container = new GameObject("BackgroundContainer");
+            container.transform.parent = scenario.transform;
+            gameObjectOneWayCache = new GameObjectOneWayCache(container.transform, prefabs.categories.Select((element) => element.Item1).ToArray());
+        }
+
         /// <summary>
         /// Generates background layers of objects at the start of each scenario iteration
         /// </summary>
         protected override void OnIterationStart()
         {
-            if (m_SpawnedObjects == null)
-                m_SpawnedObjects = new List<GameObject>();
-
             for (var i = 0; i < layerCount; i++)
             {
                 var seed = scenario.NextRandomState();
                 var placementSamples = PoissonDiskSampling.GenerateSamples(
                     placementArea.x, placementArea.y, separationDistance, seed);
                 var offset = new Vector3(placementArea.x, placementArea.y, 0f) * -0.5f;
-                var parent = scenario.transform;
                 foreach (var sample in placementSamples)
                 {
-                    var instance = Object.Instantiate(prefabs.Sample(), parent);
+                    var instance = gameObjectOneWayCache.GetOrInstantiate(prefabs.Sample());
                     instance.transform.position = new Vector3(sample.x, sample.y, separationDistance * i + depth) + offset;
-                    m_SpawnedObjects.Add(instance);
                 }
                 placementSamples.Dispose();
             }
@@ -69,9 +73,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
         /// </summary>
         protected override void OnIterationEnd()
         {
-            foreach (var spawnedObject in m_SpawnedObjects)
-                Object.Destroy(spawnedObject);
-            m_SpawnedObjects.Clear();
+            gameObjectOneWayCache.ResetAllObjects();
         }
     }
 }

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
@@ -38,14 +38,15 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
         /// </summary>
         public GameObjectParameter prefabs;
 
-        GameObject container;
-        GameObjectOneWayCache gameObjectOneWayCache;
+        GameObject m_Container;
+        GameObjectOneWayCache m_GameObjectOneWayCache;
 
         protected override void OnCreate()
         {
-            container = new GameObject("BackgroundContainer");
-            container.transform.parent = scenario.transform;
-            gameObjectOneWayCache = new GameObjectOneWayCache(container.transform, prefabs.categories.Select((element) => element.Item1).ToArray());
+            m_Container = new GameObject("BackgroundContainer");
+            m_Container.transform.parent = scenario.transform;
+            m_GameObjectOneWayCache = new GameObjectOneWayCache(
+                m_Container.transform, prefabs.categories.Select((element) => element.Item1).ToArray());
         }
 
         /// <summary>
@@ -61,7 +62,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
                 var offset = new Vector3(placementArea.x, placementArea.y, 0f) * -0.5f;
                 foreach (var sample in placementSamples)
                 {
-                    var instance = gameObjectOneWayCache.GetOrInstantiate(prefabs.Sample());
+                    var instance = m_GameObjectOneWayCache.GetOrInstantiate(prefabs.Sample());
                     instance.transform.position = new Vector3(sample.x, sample.y, separationDistance * i + depth) + offset;
                 }
                 placementSamples.Dispose();
@@ -73,7 +74,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
         /// </summary>
         protected override void OnIterationEnd()
         {
-            gameObjectOneWayCache.ResetAllObjects();
+            m_GameObjectOneWayCache.ResetAllObjects();
         }
     }
 }

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ForegroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ForegroundObjectPlacementRandomizer.cs
@@ -38,10 +38,9 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
         protected override void OnCreate()
         {
             m_Container = new GameObject("Foreground Objects");
-            var scenarioTransform = scenario.transform;
-            m_Container.transform.parent = scenarioTransform;
+            m_Container.transform.parent = scenario.transform;
             m_GameObjectOneWayCache = new GameObjectOneWayCache(
-                scenarioTransform, prefabs.categories.Select(element => element.Item1).ToArray());
+                m_Container.transform, prefabs.categories.Select(element => element.Item1).ToArray());
         }
 
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/GameObjectOneWayCache.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/GameObjectOneWayCache.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using Unity.Profiling;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+/// <summary>
+/// Facilitates object pooling for a pre-specified collection of prefabs with the caveat that objects can be fetched
+/// from the cache but not returned. Every frame, the cache needs to be reset, which will return all objects to the pool
+/// </summary>
+class GameObjectOneWayCache
+{
+    static ProfilerMarker s_ResetAllObjectsMarker = new ProfilerMarker("ResetAllObjects");
+    
+    // Objects will reset to this origin when not being used
+    Transform m_CacheParent;
+    Dictionary<int, int> m_InstanceIdToIndex;
+    List<GameObject>[] m_InstantiatedObjects;
+    int[] m_NumObjectsActive;
+    int NumObjectsInCache { get; set; }
+    public int NumObjectsActive { get; private set; }
+
+    public GameObjectOneWayCache(Transform parent, GameObject[] prefabs)
+    {
+        m_CacheParent = parent;
+        m_InstanceIdToIndex = new Dictionary<int, int>();
+        m_InstantiatedObjects = new List<GameObject>[prefabs.Length];
+        m_NumObjectsActive = new int[prefabs.Length];
+        
+        var index = 0;
+        foreach (var prefab in prefabs)
+        {
+            var instanceId = prefab.GetInstanceID();
+            m_InstanceIdToIndex.Add(instanceId, index);
+            m_InstantiatedObjects[index] = new List<GameObject>();
+            m_NumObjectsActive[index] = 0;
+            ++index;
+        }
+    }
+
+    public GameObject GetOrInstantiate(GameObject prefab)
+    {
+        if (!m_InstanceIdToIndex.TryGetValue(prefab.GetInstanceID(), out var index))
+        {
+            throw new ArgumentException($"Prefab {prefab.name} (ID: {prefab.GetInstanceID()}) is not in cache.");
+        }
+
+        ++NumObjectsActive;
+        if (m_NumObjectsActive[index] < m_InstantiatedObjects[index].Count)
+        {
+            var nextInCache = m_InstantiatedObjects[index][m_NumObjectsActive[index]];
+            ++m_NumObjectsActive[index];
+            return nextInCache;
+        }
+        else
+        {
+            ++NumObjectsInCache;
+            var newObject = Object.Instantiate(prefab, m_CacheParent);
+            ++m_NumObjectsActive[index];
+            m_InstantiatedObjects[index].Add(newObject);
+            return newObject;
+        }
+    }
+
+    public void ResetAllObjects()
+    {
+        using (s_ResetAllObjectsMarker.Auto())
+        {
+            NumObjectsActive = 0;
+            for (var i = 0; i < m_InstantiatedObjects.Length; ++i)
+            {
+                m_NumObjectsActive[i] = 0;
+                foreach (var obj in m_InstantiatedObjects[i])
+                {
+                    // Position outside the frame
+                    obj.transform.localPosition = new Vector3(10000, 0, 0);
+                }
+            }
+        }
+    }
+}

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/GameObjectOneWayCache.cs.meta
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/GameObjectOneWayCache.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: f71829e483594d159927c8ad5e3c8eef
+timeCreated: 1583339841


### PR DESCRIPTION
# Peer Review Information:
This PR makes it so the simulation continues to run when the editor is not focused and fixes a memory leak and crash at the end of a long simulation using the background and foreground placement randomizers.

Turns out instantiating and deleting millions of objects causes a massive hang at the end of play mode while the graphics system is cleaning up its memory. My fix is to insert the object caching we created for SynthDet.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 
Did not add tests, as the repro is inconsistent and would take too long to run.

**Core Scenario Tested**: Tested in NeuralPocket customer project

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [x] - Updated changelog
