### PR TITLE
Hex color representation in semantic segmentation label config UI

### DIFF
--- a/com.unity.perception/Editor/GroundTruth/SemanticSegmentationLabelConfigEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/SemanticSegmentationLabelConfigEditor.cs
@@ -36,6 +36,8 @@ namespace UnityEditor.Perception.GroundTruth
                         .FindPropertyRelative(nameof(SemanticSegmentationLabelEntry.label)));
                     addedLabel.colorField.BindProperty(m_SerializedLabelsArray.GetArrayElementAtIndex(i)
                         .FindPropertyRelative(nameof(SemanticSegmentationLabelEntry.color)));
+                    addedLabel.hexLabel.text = "#"+ColorUtility.ToHtmlStringRGBA(m_SerializedLabelsArray.GetArrayElementAtIndex(i)
+                        .FindPropertyRelative(nameof(SemanticSegmentationLabelEntry.color)).colorValue);
                 }
             }
 
@@ -91,6 +93,7 @@ namespace UnityEditor.Perception.GroundTruth
         protected override string UxmlPath => k_UxmlDir + "ColoredLabelElementInLabelConfig.uxml";
 
         public ColorField colorField;
+        public Label hexLabel;
 
         public ColoredLabelElementInLabelConfig(LabelConfigEditor<SemanticSegmentationLabelEntry> editor, SerializedProperty labelsArray) : base(editor, labelsArray)
         { }
@@ -98,6 +101,7 @@ namespace UnityEditor.Perception.GroundTruth
         protected override void InitExtended()
         {
             colorField = this.Q<ColorField>("label-color-value");
+            hexLabel = this.Q<Label>("label-color-hex");
 
             colorField.RegisterValueChangedCallback((cEvent) =>
             {
@@ -111,6 +115,8 @@ namespace UnityEditor.Perception.GroundTruth
 
                     Debug.LogWarning("A label with the chosen color " + cEvent.newValue + " has already been added to this label configuration.");
                 }
+
+                hexLabel.text = "#"+ColorUtility.ToHtmlStringRGBA(colorField.value);
             });
 
         }

--- a/com.unity.perception/Editor/GroundTruth/Uxml/ColoredLabelElementInLabelConfig.uxml
+++ b/com.unity.perception/Editor/GroundTruth/Uxml/ColoredLabelElementInLabelConfig.uxml
@@ -2,8 +2,9 @@
     <VisualElement class="added-label" style="padding-top: 3px;">
         <Button name="remove-button" class="labeling__remove-item-button"/>
         <VisualElement class="generic-hover"
-                       style="flex-direction: row; padding: 3px 0 3px 6px; margin-left: 3px; margin-right: 3px; border-width: 1px; border-color: #555555; border-radius: 4px;">
-            <editor:ColorField name="label-color-value" style="min-width : 60px; max-width: 60px; align-self:center;"/>
+                       style="min-width : 137px; flex-direction: row; padding: 3px 0 3px 6px; margin-left: 3px; margin-right: 3px; border-width: 1px; border-color: #555555; border-radius: 4px;">
+            <editor:ColorField name="label-color-value" style="min-width : 60px; max-width: 60px; align-self:center; margin:2px"/>
+            <Label name="label-color-hex" style="font-size: 11; min-width : 60px; max-width: 60px; align-self:center;"/>
         </VisualElement>
         <TextField name="label-value" class="labeling__added-label-value"/>
         <VisualElement style="min-width:20px; flex-direction: row; display:none">


### PR DESCRIPTION
# Peer Review Information:
Information on any code, feature, documentation changes here

Added hex color representation to semantic segmentation label config UI. These labels are purely for display and cannot be interacted with. The purpose of the label is to help the user verify whether the colours are different or not.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
