### PR TITLE
Fix for breaking change in capture refactor.

### DIFF
--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -224,7 +224,7 @@ namespace UnityEngine.Perception.GroundTruth
             // Currently there is an issue in the perception camera that causes the UI layer not to be visualized
             // if we are utilizing async readback and we have to flip our captured image. We have created a jira
             // issue for this (aisv-779) and have notified the engine team about this.
-            anyVisualizing = false;
+            anyVisualizing = true;
 
             if (m_ShowingVisualizations)
                 CaptureOptions.useAsyncReadbackIfSupported = !anyVisualizing;

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -224,7 +224,7 @@ namespace UnityEngine.Perception.GroundTruth
             // Currently there is an issue in the perception camera that causes the UI layer not to be visualized
             // if we are utilizing async readback and we have to flip our captured image. We have created a jira
             // issue for this (aisv-779) and have notified the engine team about this.
-            anyVisualizing = true;
+            anyVisualizing = false;
 
             if (m_ShowingVisualizations)
                 CaptureOptions.useAsyncReadbackIfSupported = !anyVisualizing;
@@ -373,8 +373,11 @@ namespace UnityEngine.Perception.GroundTruth
                 }
             };
 
+#if SIMULATION_CAPTURE_0_0_10_PREVIEW_16_OR_NEWER
+            CaptureCamera.Capture(cam, colorFunctor, forceFlip: ForceFlip.None);
+#else
             CaptureCamera.Capture(cam, colorFunctor, flipY: flipY);
-
+#endif
             Profiler.EndSample();
         }
 

--- a/com.unity.perception/Runtime/Unity.Perception.Runtime.asmdef
+++ b/com.unity.perception/Runtime/Unity.Perception.Runtime.asmdef
@@ -33,6 +33,11 @@
             "name": "com.unity.render-pipelines.universal",
             "expression": "",
             "define": "URP_PRESENT"
+        },
+        {
+            "name": "com.unity.simulation.capture",
+            "expression": "0.0.10-preview.16",
+            "define": "SIMULATION_CAPTURE_0_0_10_PREVIEW_16_OR_NEWER"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
FlipY is correct by default in preview.16 and later

# Peer Review Information:

1. The latest capture package accesses and uses the render targets that URP/HDRP create. This means that even if the camera doesn't have a target, it is still rendering to a RT, and generally won't need to be flipped.  

2. Take a look at the second commit in this PR. I tested with anyVisualizing = false, and it seems to work correctly now.

## Editor / Package versioning:
The latest capture package will support 2019.4 onwards.

## Dev Testing:
No tests have been added in the PR, but the capture package has many tests for validating orientation for each pipeline.

**Core Scenario Tested**: 
Tested with PerceptionURP, PerceptionHDRP

**Notes + Expectations**: 
Expectation is that with this change, upgrading to .16 will cause no output changes with the perception package.

