### PR TITLE
On create randomizer fix

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -43,6 +43,8 @@ Fixed the simulation stopping while the editor/player is not focused
 
 Fixed memory leak or crash occurring at the end of long simulations when using BackgroundObjectPlacementRandomizer or ForegroundObjectPlacementRandomizer
 
+Randomizer.OnCreate() is no longer called in edit-mode when adding a randomizer to a scenario
+
 ## [0.6.0-preview.1] - 2020-12-03
 
 ### Added

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -310,7 +310,12 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
                         $"Two Randomizers of the same type ({randomizerType.Name}) cannot both be active simultaneously");
             var newRandomizer = (Randomizer)Activator.CreateInstance(randomizerType);
             m_Randomizers.Add(newRandomizer);
+#if UNITY_EDITOR
+            if (Application.isPlaying)
+                newRandomizer.Create();
+#else
             newRandomizer.Create();
+#endif
             return newRandomizer;
         }
 

--- a/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
+++ b/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
@@ -1,0 +1,49 @@
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Experimental.Perception.Randomization.Randomizers;
+using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+
+namespace EditorTests
+{
+    [TestFixture]
+    public class RandomizerEditorTests
+    {
+        GameObject m_TestObject;
+        FixedLengthScenario m_Scenario;
+
+        [SetUp]
+        public void Setup()
+        {
+            m_TestObject = new GameObject();
+            m_Scenario = m_TestObject.AddComponent<FixedLengthScenario>();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            Object.DestroyImmediate(m_TestObject);
+        }
+
+        [Test]
+        public void RandomizerOnCreateMethodNotCalledInEditMode()
+        {
+            // TestRandomizer.OnCreate() should NOT be called here while in edit-mode
+            // if ScenarioBase.CreateRandomizer<>() was coded correctly
+            Assert.DoesNotThrow(() =>
+            {
+                m_Scenario.CreateRandomizer<ErrorsOnCreateTestRandomizer>();
+            });
+        }
+    }
+
+    [AddRandomizerMenu("Test Randomizers/Errors OnCreate Test Randomizer")]
+    class ErrorsOnCreateTestRandomizer : Randomizer
+    {
+        public GameObject testGameObject;
+
+        protected override void OnCreate()
+        {
+            testGameObject.transform.position = Vector3.zero;
+        }
+    }
+}

--- a/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
+++ b/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
@@ -46,5 +46,10 @@ namespace EditorTests
             // This line should throw a NullReferenceException
             testGameObject.transform.position = Vector3.zero;
         }
+
+        protected override void OnIterationStart()
+        {
+            testGameObject = new GameObject("Test");
+        }
     }
 }

--- a/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
+++ b/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
@@ -49,5 +49,10 @@ namespace EditorTests
             // This line should throw a NullReferenceException
             testGameObject.transform.position = Vector3.zero;
         }
+
+        protected override void OnIterationStart()
+        {
+            testGameObject = new GameObject("Test");
+        }
     }
 }

--- a/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
+++ b/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
@@ -1,7 +1,9 @@
+using System;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.Experimental.Perception.Randomization.Randomizers;
 using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using Object = UnityEngine.Object;
 
 namespace EditorTests
 {
@@ -36,6 +38,7 @@ namespace EditorTests
         }
     }
 
+    [Serializable]
     [AddRandomizerMenu("Test Randomizers/Errors OnCreate Test Randomizer")]
     class ErrorsOnCreateTestRandomizer : Randomizer
     {
@@ -45,11 +48,6 @@ namespace EditorTests
         {
             // This line should throw a NullReferenceException
             testGameObject.transform.position = Vector3.zero;
-        }
-
-        protected override void OnIterationStart()
-        {
-            testGameObject = new GameObject("Test");
         }
     }
 }

--- a/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
+++ b/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
@@ -43,6 +43,7 @@ namespace EditorTests
 
         protected override void OnCreate()
         {
+            // This line should throw a NullReferenceException
             testGameObject.transform.position = Vector3.zero;
         }
     }

--- a/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs.meta
+++ b/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 26d4a82fa0c640349e6d89fe1c536b72
+timeCreated: 1610137610


### PR DESCRIPTION
# Peer Review Information:
This PR fixes a bug where the OnCreate() method on Randomizers was incorrectly called in edit-mode when a user adds a randomizer to a scenario.

## Editor / Package versioning:
**Editor Version Target)**: 2019.4

## Dev Testing:
**Tests Added**: 
Added an edit-mode test to confirm that OnCreate() is not called when adding a randomizer to a scenario in edit-mode.

## Checklist
- [X] - Updated changelog
