### PR TITLE
Decouple RandomizerTagManager from Scenarios

### DIFF
--- a/com.unity.perception/Runtime/Randomization/Randomizers/Randomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/Randomizer.cs
@@ -33,7 +33,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
         /// <summary>
         /// Retrieves the RandomizerTagManager of the scenario containing this Randomizer
         /// </summary>
-        public RandomizerTagManager tagManager => scenario.tagManager;
+        public RandomizerTagManager tagManager => RandomizerTagManager.singleton;
 
         internal IEnumerable<Parameter> parameters
         {

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
@@ -41,6 +41,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
         GameObject m_Container;
         GameObjectOneWayCache m_GameObjectOneWayCache;
 
+        /// <inheritdoc/>
         protected override void OnCreate()
         {
             m_Container = new GameObject("BackgroundContainer");

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ForegroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ForegroundObjectPlacementRandomizer.cs
@@ -35,6 +35,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
         GameObject m_Container;
         GameObjectOneWayCache m_GameObjectOneWayCache;
 
+        /// <inheritdoc/>
         protected override void OnCreate()
         {
             m_Container = new GameObject("Foreground Objects");

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
 
 namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
 {
@@ -10,18 +9,16 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
     [Serializable]
     public abstract class RandomizerTag : MonoBehaviour
     {
-        ScenarioBase scenario => ScenarioBase.activeScenario;
+        RandomizerTagManager tagManager => RandomizerTagManager.singleton;
 
         void Awake()
         {
-            if (scenario)
-                scenario.tagManager.AddTag(GetType(), gameObject);
+            tagManager.AddTag(GetType(), gameObject);
         }
 
         void OnDestroy()
         {
-            if (scenario)
-                scenario.tagManager.RemoveTag(GetType(), gameObject);
+            tagManager.RemoveTag(GetType(), gameObject);
         }
     }
 }

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
@@ -10,14 +10,16 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
     [Serializable]
     public abstract class RandomizerTag : MonoBehaviour
     {
+        ScenarioBase scenario => ScenarioBase.activeScenario;
+
         void Awake()
         {
-            ScenarioBase.activeScenario.tagManager.AddTag(GetType(), gameObject);
+            if (scenario)
+                scenario.tagManager.AddTag(GetType(), gameObject);
         }
 
         void OnDestroy()
         {
-            var scenario = ScenarioBase.activeScenario;
             if (scenario)
                 scenario.tagManager.RemoveTag(GetType(), gameObject);
         }

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
@@ -10,6 +10,8 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
     /// </summary>
     public class RandomizerTagManager
     {
+        public static RandomizerTagManager singleton { get; } = new RandomizerTagManager();
+
         Dictionary<Type, HashSet<Type>> m_TypeTree = new Dictionary<Type, HashSet<Type>>();
         Dictionary<Type, HashSet<GameObject>> m_TagMap = new Dictionary<Type, HashSet<GameObject>>();
 

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
@@ -10,6 +10,9 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
     /// </summary>
     public class RandomizerTagManager
     {
+        /// <summary>
+        /// Returns the singleton RandomizerTagManager instance
+        /// </summary>
         public static RandomizerTagManager singleton { get; } = new RandomizerTagManager();
 
         Dictionary<Type, HashSet<Type>> m_TypeTree = new Dictionary<Type, HashSet<Type>>();

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -7,7 +7,6 @@ using UnityEngine.Experimental.Perception.Randomization.Parameters;
 using UnityEngine.Experimental.Perception.Randomization.Randomizers;
 using UnityEngine.Experimental.Perception.Randomization.Samplers;
 using UnityEngine.Perception.GroundTruth;
-using UnityEngine.Rendering;
 
 namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
 {
@@ -23,7 +22,6 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
         bool m_SkipFrame = true;
         bool m_FirstScenarioFrame = true;
         bool m_WaitingForFinalUploads;
-        RandomizerTagManager m_TagManager = new RandomizerTagManager();
 
         IEnumerable<Randomizer> activeRandomizers
         {
@@ -37,11 +35,6 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
 
         // ReSharper disable once InconsistentNaming
         [SerializeReference] internal List<Randomizer> m_Randomizers = new List<Randomizer>();
-
-        /// <summary>
-        /// The RandomizerTagManager attached to this scenario
-        /// </summary>
-        public RandomizerTagManager tagManager => m_TagManager;
 
         /// <summary>
         /// Return the list of randomizers attached to this scenario

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -194,6 +194,16 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
                 m_SkipFrame = false;
         }
 
+        void OnEnable()
+        {
+            activeScenario = this;
+        }
+
+        void OnDisable()
+        {
+            activeScenario = null;
+        }
+
         void Start()
         {
             var randomSeedMetricDefinition = DatasetCapture.RegisterMetricDefinition(

--- a/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/RandomizerTagTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/RandomizerTagTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
+using UnityEngine.Experimental.Perception.Randomization.Randomizers;
 using UnityEngine.Experimental.Perception.Randomization.Scenarios;
 using Assert = Unity.Assertions.Assert;
 
@@ -40,13 +41,14 @@ namespace RandomizationTests.RandomizerTests
             for (var i = 0; i < copyCount - 1; i++)
                 Object.Instantiate(gameObject2);
 
-            var queriedObjects = m_Scenario.tagManager.Query<ExampleTag>().ToArray();
+            var tagManager = RandomizerTagManager.singleton;
+            var queriedObjects = tagManager.Query<ExampleTag>().ToArray();
             Assert.AreEqual(queriedObjects.Length, copyCount);
 
-            queriedObjects = m_Scenario.tagManager.Query<ExampleTag2>().ToArray();
+            queriedObjects = tagManager.Query<ExampleTag2>().ToArray();
             Assert.AreEqual(queriedObjects.Length, copyCount);
 
-            queriedObjects = m_Scenario.tagManager.Query<ExampleTag>(true).ToArray();
+            queriedObjects = tagManager.Query<ExampleTag>(true).ToArray();
             Assert.AreEqual(queriedObjects.Length, copyCount * 2);
         }
     }


### PR DESCRIPTION
# Peer Review Information:
This PR decouples the RandomizerTagManager from the ScenarioBase class to ensure that RandomizerTags are properly tracked even when the active scenario is disabled.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
