### PR TITLE
Remove all randomizers bug

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -56,6 +56,8 @@ Fixed memory leak or crash occurring at the end of long simulations when using B
 
 Randomizer.OnCreate() is no longer called in edit-mode when adding a randomizer to a scenario
 
+Fixed a bug where removing all randomizers from a scenario caused the randomizer container UI element to overflow over the end of Scenario component UI
+
 ## [0.6.0-preview.1] - 2020-12-03
 
 ### Added

--- a/com.unity.perception/Editor/Randomization/Uxml/Randomizer/RandomizerList.uxml
+++ b/com.unity.perception/Editor/Randomization/Uxml/Randomizer/RandomizerList.uxml
@@ -1,8 +1,10 @@
 ﻿<UXML xmlns="UnityEngine.UIElements">
-    <VisualElement name="randomizers-container" class="scenario__dark-viewport" style="margin-top: 6px; min-height: 100px;"/>
-    <VisualElement style="flex-direction: row; align-items: center; justify-content: center; margin-top: 4px;">
-        <Button name="add-randomizer-button" text="Add Randomizer"/>
-        <Button name="expand-all" text="Expand All"/>
-        <Button name="collapse-all" text="Collapse All"/>
+    <VisualElement style="min-height: 132px;">
+        <VisualElement name="randomizers-container" class="scenario__dark-viewport" style="margin-top: 6px; min-height: 100px;"/>
+        <VisualElement style="flex-direction: row; align-items: center; justify-content: center; margin-top: 4px;">
+            <Button name="add-randomizer-button" text="Add Randomizer"/>
+            <Button name="expand-all" text="Expand All"/>
+            <Button name="collapse-all" text="Collapse All"/>
+        </VisualElement>
     </VisualElement>
 </UXML>

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/AddRandomizerMenu.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/AddRandomizerMenu.cs
@@ -193,9 +193,14 @@ namespace UnityEngine.Experimental.Perception.Randomization.VisualElements
         {
             var rootList = new List<MenuItem>();
             m_MenuItemsMap.Add(string.Empty, rootList);
+
+            var randomizerTypeSet = new HashSet<Type>();
+            foreach (var randomizer in m_RandomizerList.scenario.m_Randomizers)
+                randomizerTypeSet.Add(randomizer.GetType());
+
             foreach (var randomizerType in StaticData.randomizerTypes)
             {
-                if (m_RandomizerList.randomizerTypeSet.Contains(randomizerType))
+                if (randomizerTypeSet.Contains(randomizerType))
                     continue;
                 var menuAttribute = (AddRandomizerMenuAttribute)Attribute.GetCustomAttribute(randomizerType, typeof(AddRandomizerMenuAttribute));
                 if (menuAttribute != null)

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerList.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerList.cs
@@ -12,10 +12,8 @@ namespace UnityEngine.Experimental.Perception.Randomization.VisualElements
     {
         SerializedProperty m_Property;
         VisualElement m_Container;
-        ToolbarMenu m_AddRandomizerMenu;
-        public HashSet<Type> randomizerTypeSet = new HashSet<Type>();
 
-        ScenarioBase scenario => (ScenarioBase)m_Property.serializedObject.targetObject;
+        public ScenarioBase scenario => (ScenarioBase)m_Property.serializedObject.targetObject;
 
         VisualElement inspectorContainer
         {
@@ -61,9 +59,6 @@ namespace UnityEngine.Experimental.Perception.Randomization.VisualElements
             m_Container.Clear();
             for (var i = 0; i < m_Property.arraySize; i++)
                 m_Container.Add(new RandomizerElement(m_Property.GetArrayElementAtIndex(i), this));
-            randomizerTypeSet.Clear();
-            foreach (var randomizer in scenario.randomizers)
-                randomizerTypeSet.Add(randomizer.GetType());
         }
 
         public void AddRandomizer(Type randomizerType)

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -335,7 +335,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
         {
             if (!randomizerType.IsSubclassOf(typeof(Randomizer)))
                 throw new ScenarioException(
-                    $"Cannot add non-randomizer type {randomizerType.Name} to randomizer list");
+                    $"Cannot remove non-randomizer type {randomizerType.Name} from randomizer list");
             var removed = false;
             for (var i = 0; i < m_Randomizers.Count; i++)
             {


### PR DESCRIPTION
# Peer Review Information:
Fixed a bug where removing all randomizers from a scenario caused the randomizer container UI element to overflow over the end of Scenario component UI

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
