### PR TITLE
Isolate sampler random state from scenarios

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -28,11 +28,14 @@ Randomizers now access their parent scenario through the static activeScenario p
 
 Unique seeds per Sampler have been replaced with one global random seed configured via the ScenarioConstants of a Scenario
 
-Replaced ScenarioBase.GenerateRandomSeed() with ScenarioBase.NextRandomState()
+Samplers now derive their random state from the static SamplerState class instead of individual scenarios to allow parameters and samplers to be used outside of the context of a scenario
+
+Replaced ScenarioBase.GenerateRandomSeed() with SamplerState.NextRandomState() and SamplerState.CreateGenerator()
 
 ScenarioBase.Serialize() now directly returns the serialized scenario configuration JSON string instead of writing directly to a file (use SerializeToConfigFile() instead)
 
 ScenarioBase.Serialize() now not only serializes scenario constants, but also all sampler member fields on randomizers attached to the scenario
+
 
 ### Deprecated
 

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
@@ -57,7 +57,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
         {
             for (var i = 0; i < layerCount; i++)
             {
-                var seed = scenario.NextRandomState();
+                var seed = SamplerState.NextRandomState();
                 var placementSamples = PoissonDiskSampling.GenerateSamples(
                     placementArea.x, placementArea.y, separationDistance, seed);
                 var offset = new Vector3(placementArea.x, placementArea.y, 0f) * -0.5f;

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ForegroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ForegroundObjectPlacementRandomizer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 
 namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers
 {
@@ -49,7 +49,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
         /// </summary>
         protected override void OnIterationStart()
         {
-            var seed = scenario.NextRandomState();
+            var seed = SamplerState.NextRandomState();
             var placementSamples = PoissonDiskSampling.GenerateSamples(
                 placementArea.x, placementArea.y, separationDistance, seed);
             var offset = new Vector3(placementArea.x, placementArea.y, 0f) * -0.5f;

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerState.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerState.cs
@@ -1,5 +1,8 @@
 ﻿namespace UnityEngine.Experimental.Perception.Randomization.Samplers
 {
+    /// <summary>
+    /// Encapsulates the random state that all samplers mutate when generating random values
+    /// </summary>
     public static class SamplerState
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerState.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerState.cs
@@ -1,0 +1,29 @@
+﻿namespace UnityEngine.Experimental.Perception.Randomization.Samplers
+{
+    public static class SamplerState
+    {
+        /// <summary>
+        /// The central random state that all samplers mutate when generating random numbers
+        /// </summary>
+        public static uint randomState = SamplerUtility.largePrime;
+
+        /// <summary>
+        /// Creates a random number generator seeded with a unique random state
+        /// </summary>
+        /// <returns>The seeded random number generator</returns>
+        public static Unity.Mathematics.Random CreateGenerator()
+        {
+            return new Unity.Mathematics.Random { state = NextRandomState() };
+        }
+
+        /// <summary>
+        /// Generates a new random state and overwrites the old random state with the newly generated value
+        /// </summary>
+        /// <returns>The newly generated random state</returns>
+        public static uint NextRandomState()
+        {
+            randomState = SamplerUtility.Hash32NonZero(randomState);
+            return randomState;
+        }
+    }
+}

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerState.cs.meta
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerState.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dab4e2f4d003402193a82cfe926b91d0
+timeCreated: 1611261496

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/AnimationCurveSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/AnimationCurveSampler.cs
@@ -64,7 +64,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
         public float Sample()
         {
             Initialize();
-            var rng = new Unity.Mathematics.Random(ScenarioBase.activeScenario.NextRandomState());
+            var rng = SamplerState.CreateGenerator();
             return SamplerUtility.AnimationCurveSample(
                 m_IntegratedCurve, rng.NextFloat(), m_Interval, m_StartTime, m_EndTime);
         }

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
@@ -59,7 +59,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
         /// <returns>The generated sample</returns>
         public float Sample()
         {
-            var rng = new Unity.Mathematics.Random(ScenarioBase.activeScenario.NextRandomState());
+            var rng = SamplerState.CreateGenerator();
             return SamplerUtility.TruncatedNormalSample(
                 rng.NextFloat(), range.minimum, range.maximum, mean, standardDeviation);
         }

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
@@ -42,7 +42,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Samplers
         /// <returns>The generated sample</returns>
         public float Sample()
         {
-            var rng = new Unity.Mathematics.Random(ScenarioBase.activeScenario.NextRandomState());
+            var rng = SamplerState.CreateGenerator();
             return rng.NextFloat(range.minimum, range.maximum);
         }
 

--- a/com.unity.perception/Runtime/Randomization/Scenarios/Scenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/Scenario.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Reflection;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine.Experimental.Perception.Randomization.Parameters;

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -18,7 +18,6 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
     {
         static ScenarioBase s_ActiveScenario;
 
-        uint m_RandomState = SamplerUtility.largePrime;
         bool m_SkipFrame = true;
         bool m_FirstScenarioFrame = true;
         bool m_WaitingForFinalUploads;
@@ -45,11 +44,6 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
         /// If true, this scenario will quit the Unity application when it's finished executing
         /// </summary>
         [HideInInspector] public bool quitOnComplete = true;
-
-        /// <summary>
-        /// The random state of the scenario
-        /// </summary>
-        public uint randomState => m_RandomState;
 
         /// <summary>
         /// The name of the Json file this scenario's constants are serialized to/from.
@@ -268,7 +262,7 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
             if (currentIterationFrame == 0)
             {
                 DatasetCapture.StartNewSequence();
-                m_RandomState = SamplerUtility.IterateSeed((uint)currentIteration, genericConstants.randomSeed);
+                SamplerState.randomState = SamplerUtility.IterateSeed((uint)currentIteration, genericConstants.randomSeed);
                 foreach (var randomizer in activeRandomizers)
                     randomizer.IterationStart();
             }
@@ -384,16 +378,6 @@ namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
             var randomizer = m_Randomizers[currentIndex];
             m_Randomizers.RemoveAt(currentIndex);
             m_Randomizers.Insert(nextIndex, randomizer);
-        }
-
-        /// <summary>
-        /// Generates a new random state and overwrites the old random state with the newly generated value
-        /// </summary>
-        /// <returns>The newly generated random state</returns>
-        public uint NextRandomState()
-        {
-            m_RandomState = SamplerUtility.Hash32NonZero(m_RandomState);
-            return m_RandomState;
         }
 
         void ValidateParameters()

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/SamplerTestsBase.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/SamplerTestsBase.cs
@@ -34,11 +34,11 @@ namespace RandomizationTests.SamplerTests
         [Test]
         public void ConsecutiveSamplesChangesState()
         {
-            var state0 = activeScenario.randomState;
+            var state0 = SamplerState.randomState;
             m_Sampler.Sample();
-            var state1 = activeScenario.randomState;
+            var state1 = SamplerState.randomState;
             m_Sampler.Sample();
-            var state2 = activeScenario.randomState;;
+            var state2 = SamplerState.randomState;;
 
             Assert.AreNotEqual(state0, state1);
             Assert.AreNotEqual(state1, state2);

--- a/com.unity.perception/Tests/Runtime/Randomization/ScenarioTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ScenarioTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers;
+using UnityEngine.Experimental.Perception.Randomization.Samplers;
 using UnityEngine.Perception.GroundTruth;
 using UnityEngine.Experimental.Perception.Randomization.Scenarios;
 using UnityEngine.TestTools;
@@ -152,11 +153,11 @@ namespace RandomizationTests
             yield return CreateNewScenario(3, 1);
             var seeds = new uint[3];
             for (var i = 0; i < 3; i++)
-                seeds[i] = m_Scenario.NextRandomState();
+                seeds[i] = SamplerState.NextRandomState();
 
             yield return null;
             for (var i = 0; i < 3; i++)
-                Assert.AreNotEqual(seeds[i], m_Scenario.NextRandomState());
+                Assert.AreNotEqual(seeds[i], SamplerState.NextRandomState());
         }
 
         PerceptionCamera SetupPerceptionCamera()


### PR DESCRIPTION
# Peer Review Information:
With this PR, the random state tracked inside scenarios has been moved to its own publicly accessible static class. This will allow samplers and parameters to be used without requiring a scenario to be active in the scene.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
