### PR TITLE
Output dir shortcut

### DIFF
--- a/com.unity.perception/Editor/GroundTruth/PerceptionCameraEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/PerceptionCameraEditor.cs
@@ -94,7 +94,7 @@ namespace UnityEditor.Perception.GroundTruth
             var dir = PlayerPrefs.GetString(SimulationState.latestOutputDirectoryKey, string.Empty);
             if (dir != string.Empty)
             {
-                EditorGUILayout.LabelField("Latest Output Folder:");
+                EditorGUILayout.LabelField("Latest Output Folder");
                 GUILayout.BeginVertical("TextArea");
                 EditorGUILayout.HelpBox(dir, MessageType.None);
                 GUILayout.BeginHorizontal();

--- a/com.unity.perception/Editor/GroundTruth/PerceptionCameraEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/PerceptionCameraEditor.cs
@@ -90,6 +90,26 @@ namespace UnityEditor.Perception.GroundTruth
                 //EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(PerceptionCamera.labelers)));
                 m_LabelersList.DoLayoutList();
             }
+
+            var dir = PlayerPrefs.GetString(SimulationState.latestOutputDirectoryKey, string.Empty);
+            if (dir != string.Empty)
+            {
+                EditorGUILayout.LabelField("Latest Output Folder:");
+                GUILayout.BeginVertical("TextArea");
+                EditorGUILayout.HelpBox(dir, MessageType.None);
+                GUILayout.BeginHorizontal();
+                if (GUILayout.Button("Show Folder"))
+                {
+                    EditorUtility.RevealInFinder(dir);
+                }
+                if (GUILayout.Button("Copy Path"))
+                {
+                    GUIUtility.systemCopyBuffer = dir;
+                }
+                GUILayout.EndHorizontal();
+                GUILayout.EndVertical();
+            }
+
             if (EditorSettings.asyncShaderCompilation)
             {
                 EditorGUILayout.HelpBox("Asynchronous shader compilation may result in invalid data in beginning frames. " +

--- a/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
@@ -50,6 +50,7 @@ namespace UnityEngine.Perception.GroundTruth
         float m_LastTimeScale;
         readonly string m_OutputDirectoryName;
         string m_OutputDirectoryPath;
+        public const string latestOutputDirectoryKey = "latestOutputDirectory";
 
         JsonSerializer m_AnnotationSerializer;
         public bool IsRunning { get; private set; }
@@ -77,6 +78,9 @@ namespace UnityEngine.Perception.GroundTruth
             m_AnnotationSerializer.Converters.Add(new Vector3Converter());
             m_AnnotationSerializer.Converters.Add(new QuaternionConverter());
             m_OutputDirectoryName = outputDirectory;
+
+            PlayerPrefs.SetString(latestOutputDirectoryKey, Manager.Instance.GetDirectoryFor("",""));
+
             IsRunning = true;
         }
 


### PR DESCRIPTION
# Peer Review Information:
Information on any code, feature, documentation changes here

* Added two buttons to the Perception Camera's inspector for opening the latest output folder and copying its path to clipboard.
  * Although the buttons are added to the Perception Camera, the directory is the same across all sensors for each run. It changes on each run. But since most (if not all) of our users seem to use a single camera, this solution should be OK for now.
  
## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
