### PR TITLE
Make TextureRandomizer compatible with HDRP

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -72,6 +72,9 @@ Fixed a bug where removing all randomizers from a scenario caused the randomizer
 
 Semantic Segmentation Labeler now produces output in the proper form for distributed data generation on Unity Simulation by placing output in randomized directory names
 
+Texture Randomizer is now compatible works with HDRP
+
+
 ## [0.6.0-preview.1] - 2020-12-03
 
 ### Added

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -72,7 +72,7 @@ Fixed a bug where removing all randomizers from a scenario caused the randomizer
 
 Semantic Segmentation Labeler now produces output in the proper form for distributed data generation on Unity Simulation by placing output in randomized directory names
 
-Texture Randomizer is now compatible works with HDRP
+Texture Randomizer is now compatible with HDRP
 
 
 ## [0.6.0-preview.1] - 2020-12-03

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/TextureRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/TextureRandomizer.cs
@@ -11,7 +11,11 @@ namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRa
     [AddRandomizerMenu("Perception/Texture Randomizer")]
     public class TextureRandomizer : Randomizer
     {
+#if HDRP_PRESENT
+        static readonly int k_BaseTexture = Shader.PropertyToID("_BaseColorMap");
+#else
         static readonly int k_BaseTexture = Shader.PropertyToID("_BaseMap");
+#endif
 
         /// <summary>
         /// The list of textures to sample and apply to tagged objects


### PR DESCRIPTION
# Peer Review Information:
This PR adds a compiler check to the TextureRandomizer to use a different material property name in HDRP vs URP.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
