### PR TITLE
Removed randomization tooling from the experimental namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In-depth documentation on individual components of the package.
 |[Label Config](com.unity.perception/Documentation~/GroundTruthLabeling.md#label-config)|An asset that defines a taxonomy of labels for ground truth generation|
 |[Perception Camera](com.unity.perception/Documentation~/PerceptionCamera.md)|Captures RGB images and ground truth from a [Camera](https://docs.unity3d.com/Manual/class-Camera.html).|
 |[Dataset Capture](com.unity.perception/Documentation~/DatasetCapture.md)|Ensures sensors are triggered at proper rates and accepts data for the JSON dataset.|
-|[Randomization (Experimental)](com.unity.perception/Documentation~/Randomization/Index.md)|The Randomization tool set lets you integrate domain randomization principles into your simulation.|
+|[Randomization](com.unity.perception/Documentation~/Randomization/Index.md)|The Randomization tool set lets you integrate domain randomization principles into your simulation.|
 
 ## Example Projects
 

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -63,6 +63,8 @@ Removed native sampling (through jobs) capability from all samplers and paramete
 
 Removed `range` as a required ISampler interface property.
 
+Removed randomization tooling from the "Experimental" namespace
+
 ### Fixed
 
 Fixed an issue where the overlay panel would display a full screen semi-transparent image over the entire screen when the overlay panel is disabled in the UI
@@ -117,7 +119,6 @@ The ScenarioBase's GenerateIterativeRandomSeed() method has been renamed to Gene
 ### Removed
 
 ### Fixed
-
 
 UnitySimulationScenario now correctly deserializes app-params before offsetting the current scenario iteration when executing on Unity Simulation.
 

--- a/com.unity.perception/Documentation~/Randomization/Index.md
+++ b/com.unity.perception/Documentation~/Randomization/Index.md
@@ -1,7 +1,5 @@
 # Overview
 
-*NOTE: The Perception package's randomization toolset is currently marked as experimental and is subject to change.*
-
 The randomization toolset simplifies randomizing aspects of generating synthetic data. It facilitates exposing parameters for randomization, offers samplers to pick random values from parameters, and provides Scenarios to coordinate a full randomization process. Each of these also allows for custom implementations to fit particular randomization needs.
 
 #### What is Domain Randomization?

--- a/com.unity.perception/Documentation~/Randomization/Parameters.md
+++ b/com.unity.perception/Documentation~/Randomization/Parameters.md
@@ -49,7 +49,7 @@ using UnityEngine.Perception.Editor;
 public class CustomMonoBehaviourEditor : ParameterUIElementsEditor { }
 ``` 
 
-**_Note_**: Any editor scripts must be placed inside an "Editor" folder within your project. "Editor" is a [special folder name](https://docs.unity3d.com/Manual/SpecialFolders.html) in Unity that prevents editor code from compiling into a player during the build process. For example, the file path for the ClusterEditor script above could be ".../Assets/Scripts/Editor/CustomMonoBehaviourEditor".
+**_Note_**: Any editor scripts must be placed inside an "Editor" folder within your project. "Editor" is a [special folder name](https://docs.unity3d.com/Manual/SpecialFolders.html) in Unity that prevents editor code from compiling into a player during the build process. For example, the file path for the CustomMonoBehaviourEditor script above could be ".../Assets/Scripts/Editor/CustomMonoBehaviourEditor".
 
 ### Categorical Parameters
 

--- a/com.unity.perception/Documentation~/Randomization/Parameters.md
+++ b/com.unity.perception/Documentation~/Randomization/Parameters.md
@@ -31,7 +31,7 @@ After adding a public Parameter field to a MonoBehaviour or ScriptableObject, yo
 Say you have the following CustomMonoBehaviour that has a public GameObjectParameter field:
 ```
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Parameters;
 
 public class CustomMonoBehaviour : MonoBehaviour
 {
@@ -43,10 +43,10 @@ To force Unity to use UI Elements to render your CustomMonoBehaviour's inspector
 
 ```
 using UnityEditor;
-using UnityEngine.Experimental.Perception.Editor;
+using UnityEngine.Perception.Editor;
 
 [CustomEditor(typeof(CustomMonoBehaviour))]
-public class TestClusterEditor : DefaultUIElementsEditor { }
+public class TestClusterEditor : ParameterUIElementsEditor { }
 ``` 
 
 ### Categorical Parameters

--- a/com.unity.perception/Documentation~/Randomization/Parameters.md
+++ b/com.unity.perception/Documentation~/Randomization/Parameters.md
@@ -26,7 +26,7 @@ All Parameters derive from the `Parameter` abstract class. Additionally, the Par
 
 ## Using Parameters outside of Randomizers (ie: in MonoBehaviours and ScriptableObjects)
 
-After adding a public Parameter field to a MonoBehaviour or ScriptableObject, you may have noticed that the Parameter's UI doesn't look the same as it does when added to a Randomizer. This is because the Inspector UI for most Perception randomization components is authored using Unity's relatively new UI Elements framework, though by default, Unity uses the old IMGUI framework to render default inspector editors.
+After adding a public Parameter field to a MonoBehaviour or ScriptableObject, you may have noticed that the Parameter's UI does not look the same as it does when added to a Randomizer. This is because the Inspector UI for most Perception randomization components is authored using Unity's relatively new UI Elements framework, though by default, Unity uses the old IMGUI framework to render default inspector editors.
 
 Say you have the following CustomMonoBehaviour that has a public GameObjectParameter field:
 ```
@@ -46,8 +46,10 @@ using UnityEditor;
 using UnityEngine.Perception.Editor;
 
 [CustomEditor(typeof(CustomMonoBehaviour))]
-public class TestClusterEditor : ParameterUIElementsEditor { }
+public class CustomMonoBehaviourEditor : ParameterUIElementsEditor { }
 ``` 
+
+**_Note_**: Any editor scripts must be placed inside an "Editor" folder within your project. "Editor" is a special folder name in Unity that prevents editor code from compiling into a player during the build process. For example, the file path for the ClusterEditor script above could be ".../Assets/Scripts/Editor/CustomMonoBehaviourEditor".
 
 ### Categorical Parameters
 

--- a/com.unity.perception/Documentation~/Randomization/Parameters.md
+++ b/com.unity.perception/Documentation~/Randomization/Parameters.md
@@ -49,7 +49,7 @@ using UnityEngine.Perception.Editor;
 public class CustomMonoBehaviourEditor : ParameterUIElementsEditor { }
 ``` 
 
-**_Note_**: Any editor scripts must be placed inside an "Editor" folder within your project. "Editor" is a special folder name in Unity that prevents editor code from compiling into a player during the build process. For example, the file path for the ClusterEditor script above could be ".../Assets/Scripts/Editor/CustomMonoBehaviourEditor".
+**_Note_**: Any editor scripts must be placed inside an "Editor" folder within your project. "Editor" is a [special folder name](https://docs.unity3d.com/Manual/SpecialFolders.html) in Unity that prevents editor code from compiling into a player during the build process. For example, the file path for the ClusterEditor script above could be ".../Assets/Scripts/Editor/CustomMonoBehaviourEditor".
 
 ### Categorical Parameters
 

--- a/com.unity.perception/Documentation~/Tutorial/Phase2.md
+++ b/com.unity.perception/Documentation~/Tutorial/Phase2.md
@@ -22,8 +22,8 @@ Note that while _**Visual Studio**_ is the default option, you can choose any te
 ```C#
 using System;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers;
 
 [Serializable]
 [AddRandomizerMenu("Perception/My Light Randomizer")]
@@ -71,7 +71,7 @@ The `OnIterationStart()` function is used for telling the Randomizer what action
 
 ```C#
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Randomizers;
 
 [AddComponentMenu("Perception/RandomizerTags/MyLightRandomizerTag")]
 [RequireComponent(typeof(Light))]
@@ -142,7 +142,7 @@ This makes the two lights illuminate the scene from opposing angles, each having
 * **:green_circle: Action**: Open `MyLightRandomizerTag.cs` and modify it to match the code below:
 ```C#
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Randomizers;
 
 [AddComponentMenu("Perception/RandomizerTags/MyLightRandomizerTag")]
 [RequireComponent(typeof(Light))]
@@ -178,8 +178,8 @@ We also need to make a minor change to `MyLightRandomizer.cs` in order to make i
 ```C#
 using System;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers;
 
 [Serializable]
 [AddRandomizerMenu("Perception/My Light Randomizer")]

--- a/com.unity.perception/Editor/Randomization/Editors/PerceptionEditorAnalytics.cs
+++ b/com.unity.perception/Editor/Randomization/Editors/PerceptionEditorAnalytics.cs
@@ -2,7 +2,7 @@
 using JetBrains.Annotations;
 using UnityEngine.Analytics;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     static class PerceptionEditorAnalytics
     {

--- a/com.unity.perception/Editor/Randomization/Editors/RandomizerTagEditor.cs
+++ b/com.unity.perception/Editor/Randomization/Editors/RandomizerTagEditor.cs
@@ -1,9 +1,9 @@
 ﻿using UnityEditor;
 using UnityEditor.UIElements;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Randomizers;
 using UnityEngine.UIElements;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Editor
+namespace UnityEngine.Perception.Randomization.Editor
 {
     [CustomEditor(typeof(RandomizerTag), true)]
     public class RandomizerTagEditor : UnityEditor.Editor

--- a/com.unity.perception/Editor/Randomization/Editors/RunInUnitySimulationWindow.cs
+++ b/com.unity.perception/Editor/Randomization/Editors/RunInUnitySimulationWindow.cs
@@ -9,12 +9,12 @@ using Unity.Simulation.Client;
 using UnityEditor.Build.Reporting;
 using UnityEditor.UIElements;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Scenarios;
 using UnityEngine.SceneManagement;
 using UnityEngine.UIElements;
 using ZipUtility;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class RunInUnitySimulationWindow : EditorWindow
     {

--- a/com.unity.perception/Editor/Randomization/Editors/ScenarioBaseEditor.cs
+++ b/com.unity.perception/Editor/Randomization/Editors/ScenarioBaseEditor.cs
@@ -1,9 +1,9 @@
 ﻿using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Scenarios;
 using UnityEngine.UIElements;
 using Object = UnityEngine.Object;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     [CustomEditor(typeof(ScenarioBase), true)]
     class ScenarioBaseEditor : Editor

--- a/com.unity.perception/Editor/Randomization/PropertyDrawers/ColorHsvaDrawer.cs
+++ b/com.unity.perception/Editor/Randomization/PropertyDrawers/ColorHsvaDrawer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization.PropertyDrawers
+namespace UnityEditor.Perception.Randomization.PropertyDrawers
 {
     [CustomPropertyDrawer(typeof(ColorHsva), true)]
     class ColorHsvaDrawer : PropertyDrawer

--- a/com.unity.perception/Editor/Randomization/PropertyDrawers/FloatRangeDrawer.cs
+++ b/com.unity.perception/Editor/Randomization/PropertyDrawers/FloatRangeDrawer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization.PropertyDrawers
+namespace UnityEditor.Perception.Randomization.PropertyDrawers
 {
     [CustomPropertyDrawer(typeof(FloatRange))]
     class FloatRangeDrawer : PropertyDrawer

--- a/com.unity.perception/Editor/Randomization/PropertyDrawers/ParameterDrawer.cs
+++ b/com.unity.perception/Editor/Randomization/PropertyDrawers/ParameterDrawer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization.PropertyDrawers
+namespace UnityEditor.Perception.Randomization.PropertyDrawers
 {
     [CustomPropertyDrawer(typeof(Parameter), true)]
     class ParameterDrawer : PropertyDrawer

--- a/com.unity.perception/Editor/Randomization/PropertyDrawers/SamplerDrawer.cs
+++ b/com.unity.perception/Editor/Randomization/PropertyDrawers/SamplerDrawer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization.PropertyDrawers
+namespace UnityEditor.Perception.Randomization.PropertyDrawers
 {
     [CustomPropertyDrawer(typeof(ISampler), true)]
     class SamplerDrawer : PropertyDrawer

--- a/com.unity.perception/Editor/Randomization/Utilities/ParameterUIElementsEditor.cs
+++ b/com.unity.perception/Editor/Randomization/Utilities/ParameterUIElementsEditor.cs
@@ -2,7 +2,7 @@
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     /// <summary>
     /// Derive this class to force the Unity Editor to render the default inspector using UIElements for an Object that

--- a/com.unity.perception/Editor/Randomization/Utilities/StaticData.cs
+++ b/com.unity.perception/Editor/Randomization/Utilities/StaticData.cs
@@ -3,10 +3,10 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     static class StaticData
     {

--- a/com.unity.perception/Editor/Randomization/Utilities/UIElementsEditorUtilities.cs
+++ b/com.unity.perception/Editor/Randomization/Utilities/UIElementsEditorUtilities.cs
@@ -4,7 +4,7 @@ using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     /// <summary>
     /// This class contains a set of helper functions for simplifying the creation of UI Elements editors

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter/CategoricalOptionElement.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter/CategoricalOptionElement.cs
@@ -3,7 +3,7 @@ using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class CategoricalOptionElement : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter/ColorHsvaField.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter/ColorHsvaField.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using UnityEditor.UIElements;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class ColorHsvaField : ColorField
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter/DrawerParameterElement.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter/DrawerParameterElement.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class DrawerParameterElement : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter/ParameterElement.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter/ParameterElement.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using UnityEditor.UIElements;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.UIElements;
 using Object = UnityEngine.Object;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class ParameterElement : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/AddRandomizerMenu.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/AddRandomizerMenu.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using Unity.Mathematics;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Randomizers;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class AddRandomizerMenu : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/DragToReorderManipulator.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/DragToReorderManipulator.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using UnityEditor.Experimental.Perception.Randomization;
+using UnityEditor.Perception.Randomization;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class DragToReorderManipulator : MouseManipulator
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerElement.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerElement.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using UnityEditor.UIElements;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Randomizers;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class RandomizerElement : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerList.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerList.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Scenarios;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class RandomizerList : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerReorderingIndicator.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Randomizer/RandomizerReorderingIndicator.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class RandomizerReorderingIndicator : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Sampler/FloatRangeElement.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Sampler/FloatRangeElement.cs
@@ -3,7 +3,7 @@ using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class FloatRangeElement : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Sampler/SamplerElement.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Sampler/SamplerElement.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class SamplerElement : VisualElement
     {

--- a/com.unity.perception/Editor/Randomization/VisualElements/Sampler/SamplerInterfaceElement.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Sampler/SamplerInterfaceElement.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using UnityEditor.UIElements;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 using UnityEngine.UIElements;
 
-namespace UnityEditor.Experimental.Perception.Randomization
+namespace UnityEditor.Perception.Randomization
 {
     class SamplerInterfaceElement : VisualElement
     {

--- a/com.unity.perception/Editor/Unity.Perception.Editor.asmdef
+++ b/com.unity.perception/Editor/Unity.Perception.Editor.asmdef
@@ -1,15 +1,15 @@
 {
     "name": "Unity.Perception.Editor",
     "references": [
-        "Unity.RenderPipelines.Core.Runtime",
-        "Unity.RenderPipelines.HighDefinition.Runtime",
-        "Unity.RenderPipelines.HighDefinition.Editor",
-        "Unity.Mathematics",
-        "Unity.Entities",
         "Unity.Collections",
+        "Unity.Entities",
+        "Unity.Mathematics",
         "Unity.Perception.Runtime",
-        "UnityEngine.UI",
-        "Unity.Simulation.Client.Editor"
+        "Unity.RenderPipelines.Core.Runtime",
+        "Unity.RenderPipelines.HighDefinition.Editor",
+        "Unity.RenderPipelines.HighDefinition.Runtime",
+        "Unity.Simulation.Client.Editor",
+        "UnityEngine.UI"
     ],
     "includePlatforms": [
         "Editor"

--- a/com.unity.perception/Editor/Unity.Perception.Editor.asmdef
+++ b/com.unity.perception/Editor/Unity.Perception.Editor.asmdef
@@ -1,6 +1,5 @@
 {
     "name": "Unity.Perception.Editor",
-    "rootNamespace": "",
     "references": [
         "Unity.RenderPipelines.Core.Runtime",
         "Unity.RenderPipelines.HighDefinition.Runtime",
@@ -9,8 +8,6 @@
         "Unity.Entities",
         "Unity.Collections",
         "Unity.Perception.Runtime",
-        "PathCreatorEditor",
-        "PathCreator",
         "UnityEngine.UI",
         "Unity.Simulation.Client.Editor"
     ],

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -9,6 +10,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// </summary>
     /// <typeparam name="T">The sample type of the categorical parameter</typeparam>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public abstract class CategoricalParameter<T> : CategoricalParameterBase
     {
         [SerializeField] internal bool uniform = true;

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// Generates samples by choosing one option from a list of choices

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameterBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameterBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -7,6 +8,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// The base class of CategoricalParameters.
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public abstract class CategoricalParameterBase : Parameter
     {
         [SerializeField] internal List<float> probabilities = new List<float>();

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameterBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameterBase.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// The base class of CategoricalParameters.

--- a/com.unity.perception/Runtime/Randomization/Parameters/NumericParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/NumericParameter.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// Numeric parameters use samplers to generate randomized structs

--- a/com.unity.perception/Runtime/Randomization/Parameters/NumericParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/NumericParameter.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using Unity.Collections;
-using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -10,6 +8,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// </summary>
     /// <typeparam name="T">The sample type of the parameter</typeparam>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public abstract class NumericParameter<T> : Parameter where T : struct
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/Parameter.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// Parameters, in conjunction with a parameter configuration, are used to create convenient interfaces for

--- a/com.unity.perception/Runtime/Randomization/Parameters/Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/Parameter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -10,6 +11,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// randomizing simulations.
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public abstract class Parameter
     {
         [HideInInspector, SerializeField] internal bool collapsed;

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/AnimationClipParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/AnimationClipParameter.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -6,5 +7,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for animation clips
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class AnimationClipParameter : CategoricalParameter<AnimationClip> { }
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/AnimationClipParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/AnimationClipParameter.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A categorical parameter for animation clips

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/GameObjectParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/GameObjectParameter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -6,5 +7,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating GameObject samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class GameObjectParameter : CategoricalParameter<GameObject> { }
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/GameObjectParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/GameObjectParameter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A categorical parameter for generating GameObject samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/MaterialParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/MaterialParameter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A categorical parameter for generating Material samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/MaterialParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/MaterialParameter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -6,5 +7,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating Material samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class MaterialParameter : CategoricalParameter<Material> {}
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/StringParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/StringParameter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A categorical parameter for generating string samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/StringParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/StringParameter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -6,5 +7,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating string samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class StringParameter : CategoricalParameter<string> {}
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/Texture2DParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/Texture2DParameter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -6,5 +7,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating GameObject samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class Texture2DParameter : CategoricalParameter<Texture2D> { }
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/Texture2DParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/Texture2DParameter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A categorical parameter for generating GameObject samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/BooleanParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/BooleanParameter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Jobs;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -11,6 +9,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating boolean samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class BooleanParameter : NumericParameter<bool>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/BooleanParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/BooleanParameter.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating boolean samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsva.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsva.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Unity.Mathematics;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A struct representing the hue, saturation, value, and alpha components of a particular color

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsva.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsva.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Unity.Mathematics;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -7,6 +8,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A struct representing the hue, saturation, value, and alpha components of a particular color
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public struct ColorHsva
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaCategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaCategoricalParameter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -6,5 +7,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating ColorHsva samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class ColorHsvaCategoricalParameter : CategoricalParameter<ColorHsva> { }
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaCategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaCategoricalParameter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A categorical parameter for generating ColorHsva samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaParameter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Jobs;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -11,6 +9,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating color samples using HSVA samplers
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class ColorHsvaParameter : NumericParameter<Color>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaParameter.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating color samples using HSVA samplers

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbCategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbCategoricalParameter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -6,5 +7,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating RGBA color samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class ColorRgbCategoricalParameter : CategoricalParameter<Color> { }
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbCategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbCategoricalParameter.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A categorical parameter for generating RGBA color samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbParameter.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating RGBA color samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbParameter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Jobs;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -11,6 +9,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating RGBA color samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class ColorRgbParameter : NumericParameter<Color>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/FloatParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/FloatParameter.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating float samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/FloatParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/FloatParameter.cs
@@ -1,8 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Unity.Collections;
-using Unity.Jobs;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -10,6 +9,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating float samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class FloatParameter : NumericParameter<float>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/IntegerParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/IntegerParameter.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating integer samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/IntegerParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/IntegerParameter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Jobs;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -11,6 +9,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating integer samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class IntegerParameter : NumericParameter<int>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector2Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector2Parameter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Jobs;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -11,6 +9,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating Vector2 samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class Vector2Parameter : NumericParameter<Vector2>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector2Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector2Parameter.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating Vector2 samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector3Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector3Parameter.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating Vector3 samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector3Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector3Parameter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Jobs;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -11,6 +9,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating Vector3 samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class Vector3Parameter : NumericParameter<Vector3>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector4Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector4Parameter.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating Vector4 samples

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector4Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector4Parameter.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Jobs;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -11,6 +9,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating Vector4 samples
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class Vector4Parameter : NumericParameter<Vector4>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterValidationException.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterValidationException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Parameters
+namespace UnityEngine.Perception.Randomization.Parameters
 {
     class ParameterValidationException : Exception
     {

--- a/com.unity.perception/Runtime/Randomization/Randomizers/AddRandomizerMenuAttribute.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/AddRandomizerMenuAttribute.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Randomizers
 {
     /// <summary>
     /// The AddRandomizerMenu attribute allows you to organize randomizers under different menu paths
     /// </summary>
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Randomizers")]
     public class AddRandomizerMenuAttribute : Attribute
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Randomizers/AddRandomizerMenuAttribute.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/AddRandomizerMenuAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
+namespace UnityEngine.Perception.Randomization.Randomizers
 {
     /// <summary>
     /// The AddRandomizerMenu attribute allows you to organize randomizers under different menu paths

--- a/com.unity.perception/Runtime/Randomization/Randomizers/Randomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/Randomizer.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.Perception.Randomization.Scenarios;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Randomizers
 {
@@ -14,6 +14,7 @@ namespace UnityEngine.Perception.Randomization.Randomizers
     /// https://issuetracker.unity3d.com/issues/serializereference-non-serialized-initialized-fields-lose-their-values-when-entering-play-mode
     /// </remark>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Randomizers")]
     public abstract class Randomizer
     {
         bool m_PreviouslyEnabled;

--- a/com.unity.perception/Runtime/Randomization/Randomizers/Randomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/Randomizer.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Scenarios;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
+namespace UnityEngine.Perception.Randomization.Randomizers
 {
     /// <summary>
     /// Derive Randomizer to implement systems that randomize GameObjects and/or simulation properties.

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/AnimationRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/AnimationRandomizer.cs
@@ -1,10 +1,10 @@
 using System;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers
+namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
 {
     /// <summary>
     /// Chooses a random of frame of a random clip for a game object

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers.Utilities;
 using UnityEngine.Perception.Randomization.Samplers;
 
 namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/BackgroundObjectPlacementRandomizer.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers
+namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
 {
     /// <summary>
     /// Creates multiple layers of evenly distributed but randomly placed objects

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ColorRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ColorRandomizer.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers
+namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
 {
     /// <summary>
     /// Randomizes the material color of objects tagged with a ColorRandomizerTag

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ForegroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ForegroundObjectPlacementRandomizer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers.Utilities;
 using UnityEngine.Perception.Randomization.Samplers;
 
 namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ForegroundObjectPlacementRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/ForegroundObjectPlacementRandomizer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Linq;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers
+namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
 {
     /// <summary>
     /// Creates a 2D layer of of evenly spaced GameObjects from a given list of prefabs

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/HueOffsetRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/HueOffsetRandomizer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers
+namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
 {
     /// <summary>
     /// Randomly offsets the hue of objects tagged with a ColorRandomizerTag

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/RotationRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/RotationRandomizer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers
+namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
 {
     /// <summary>
     /// Randomizes the rotation of objects tagged with a RotationRandomizerTag

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/SunAngleRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/SunAngleRandomizer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers
+namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
 {
     /// <summary>
     /// Randomizes the rotation of directional lights tagged with a SunAngleRandomizerTag

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/TextureRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/TextureRandomizer.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers
+namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
 {
     /// <summary>
     /// Randomizes the material texture of objects tagged with a TextureRandomizerTag

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/AnimationRandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/AnimationRandomizerTag.cs
@@ -1,7 +1,7 @@
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.Perception.GroundTruth;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags
+namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags
 {
     /// <summary>
     /// Used in conjunction with a <see cref="AnimationRandomizer"/> to select a random animation frame for

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/ColorRandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/ColorRandomizerTag.cs
@@ -1,4 +1,4 @@
-﻿namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags
+﻿namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags
 {
     /// <summary>
     /// Used in conjunction with a ColorRandomizer to vary the material color of GameObjects

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/HueOffsetRandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/HueOffsetRandomizerTag.cs
@@ -1,4 +1,4 @@
-﻿namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags
+﻿namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags
 {
     /// <summary>
     /// Used in conjunction with a HueOffsetRandomizer to vary the hue of GameObjects

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/RotationRandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/RotationRandomizerTag.cs
@@ -1,4 +1,4 @@
-﻿namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags
+﻿namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags
 {
     /// <summary>
     /// Used in conjunction with a RotationRandomizer to vary the rotation of GameObjects

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/SunAngleRandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/SunAngleRandomizerTag.cs
@@ -1,4 +1,4 @@
-﻿namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags
+﻿namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags
 {
     /// <summary>
     /// Used in conjunction with a SunAngleRandomizer to vary the rotation of directional lights

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/TextureRandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Tags/TextureRandomizerTag.cs
@@ -1,4 +1,4 @@
-﻿namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers.Tags
+﻿namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers.Tags
 {
     /// <summary>
     /// Used in conjunction with a TextureRandomizer to vary the material texture of GameObjects

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/GameObjectOneWayCache.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/GameObjectOneWayCache.cs
@@ -2,78 +2,80 @@
 using System.Collections.Generic;
 using Unity.Profiling;
 using UnityEngine;
-using Object = UnityEngine.Object;
 
-/// <summary>
-/// Facilitates object pooling for a pre-specified collection of prefabs with the caveat that objects can be fetched
-/// from the cache but not returned. Every frame, the cache needs to be reset, which will return all objects to the pool
-/// </summary>
-class GameObjectOneWayCache
+namespace UnityEngine.Perception.Randomization.Randomizers.Utilities
 {
-    static ProfilerMarker s_ResetAllObjectsMarker = new ProfilerMarker("ResetAllObjects");
-    
-    // Objects will reset to this origin when not being used
-    Transform m_CacheParent;
-    Dictionary<int, int> m_InstanceIdToIndex;
-    List<GameObject>[] m_InstantiatedObjects;
-    int[] m_NumObjectsActive;
-    int NumObjectsInCache { get; set; }
-    public int NumObjectsActive { get; private set; }
-
-    public GameObjectOneWayCache(Transform parent, GameObject[] prefabs)
+    /// <summary>
+    /// Facilitates object pooling for a pre-specified collection of prefabs with the caveat that objects can be fetched
+    /// from the cache but not returned. Every frame, the cache needs to be reset, which will return all objects to the pool
+    /// </summary>
+    class GameObjectOneWayCache
     {
-        m_CacheParent = parent;
-        m_InstanceIdToIndex = new Dictionary<int, int>();
-        m_InstantiatedObjects = new List<GameObject>[prefabs.Length];
-        m_NumObjectsActive = new int[prefabs.Length];
-        
-        var index = 0;
-        foreach (var prefab in prefabs)
-        {
-            var instanceId = prefab.GetInstanceID();
-            m_InstanceIdToIndex.Add(instanceId, index);
-            m_InstantiatedObjects[index] = new List<GameObject>();
-            m_NumObjectsActive[index] = 0;
-            ++index;
-        }
-    }
+        static ProfilerMarker s_ResetAllObjectsMarker = new ProfilerMarker("ResetAllObjects");
 
-    public GameObject GetOrInstantiate(GameObject prefab)
-    {
-        if (!m_InstanceIdToIndex.TryGetValue(prefab.GetInstanceID(), out var index))
-        {
-            throw new ArgumentException($"Prefab {prefab.name} (ID: {prefab.GetInstanceID()}) is not in cache.");
-        }
+        // Objects will reset to this origin when not being used
+        Transform m_CacheParent;
+        Dictionary<int, int> m_InstanceIdToIndex;
+        List<GameObject>[] m_InstantiatedObjects;
+        int[] m_NumObjectsActive;
+        int NumObjectsInCache { get; set; }
+        public int NumObjectsActive { get; private set; }
 
-        ++NumObjectsActive;
-        if (m_NumObjectsActive[index] < m_InstantiatedObjects[index].Count)
+        public GameObjectOneWayCache(Transform parent, GameObject[] prefabs)
         {
-            var nextInCache = m_InstantiatedObjects[index][m_NumObjectsActive[index]];
-            ++m_NumObjectsActive[index];
-            return nextInCache;
-        }
-        else
-        {
-            ++NumObjectsInCache;
-            var newObject = Object.Instantiate(prefab, m_CacheParent);
-            ++m_NumObjectsActive[index];
-            m_InstantiatedObjects[index].Add(newObject);
-            return newObject;
-        }
-    }
+            m_CacheParent = parent;
+            m_InstanceIdToIndex = new Dictionary<int, int>();
+            m_InstantiatedObjects = new List<GameObject>[prefabs.Length];
+            m_NumObjectsActive = new int[prefabs.Length];
 
-    public void ResetAllObjects()
-    {
-        using (s_ResetAllObjectsMarker.Auto())
-        {
-            NumObjectsActive = 0;
-            for (var i = 0; i < m_InstantiatedObjects.Length; ++i)
+            var index = 0;
+            foreach (var prefab in prefabs)
             {
-                m_NumObjectsActive[i] = 0;
-                foreach (var obj in m_InstantiatedObjects[i])
+                var instanceId = prefab.GetInstanceID();
+                m_InstanceIdToIndex.Add(instanceId, index);
+                m_InstantiatedObjects[index] = new List<GameObject>();
+                m_NumObjectsActive[index] = 0;
+                ++index;
+            }
+        }
+
+        public GameObject GetOrInstantiate(GameObject prefab)
+        {
+            if (!m_InstanceIdToIndex.TryGetValue(prefab.GetInstanceID(), out var index))
+            {
+                throw new ArgumentException($"Prefab {prefab.name} (ID: {prefab.GetInstanceID()}) is not in cache.");
+            }
+
+            ++NumObjectsActive;
+            if (m_NumObjectsActive[index] < m_InstantiatedObjects[index].Count)
+            {
+                var nextInCache = m_InstantiatedObjects[index][m_NumObjectsActive[index]];
+                ++m_NumObjectsActive[index];
+                return nextInCache;
+            }
+            else
+            {
+                ++NumObjectsInCache;
+                var newObject = Object.Instantiate(prefab, m_CacheParent);
+                ++m_NumObjectsActive[index];
+                m_InstantiatedObjects[index].Add(newObject);
+                return newObject;
+            }
+        }
+
+        public void ResetAllObjects()
+        {
+            using (s_ResetAllObjectsMarker.Auto())
+            {
+                NumObjectsActive = 0;
+                for (var i = 0; i < m_InstantiatedObjects.Length; ++i)
                 {
-                    // Position outside the frame
-                    obj.transform.localPosition = new Vector3(10000, 0, 0);
+                    m_NumObjectsActive[i] = 0;
+                    foreach (var obj in m_InstantiatedObjects[i])
+                    {
+                        // Position outside the frame
+                        obj.transform.localPosition = new Vector3(10000, 0, 0);
+                    }
                 }
             }
         }

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
@@ -4,7 +4,7 @@ using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers
+namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
 {
     /// <summary>
     /// Utility for generating lists of poisson disk sampled points

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
@@ -3,12 +3,14 @@ using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
+using UnityEngine.Scripting.APIUpdating;
 
-namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
+namespace UnityEngine.Perception.Randomization.Randomizers.Utilities
 {
     /// <summary>
     /// Utility for generating lists of poisson disk sampled points
     /// </summary>
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers")]
     public static class PoissonDiskSampling
     {
         const int k_DefaultSamplingResolution = 30;

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
+namespace UnityEngine.Perception.Randomization.Randomizers
 {
     /// <summary>
     /// Derive the RandomizerTag class to create new tag components.

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Randomizers
 {
@@ -7,6 +8,7 @@ namespace UnityEngine.Perception.Randomization.Randomizers
     /// RandomizerTags are used to help randomizers query for a set of GameObjects to randomize.
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Randomizers")]
     public abstract class RandomizerTag : MonoBehaviour
     {
         RandomizerTagManager tagManager => RandomizerTagManager.singleton;

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Randomizers
+namespace UnityEngine.Perception.Randomization.Randomizers
 {
     /// <summary>
     /// Organizes RandomizerTags present in the scene

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using Unity.Entities;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Randomizers
 {
     /// <summary>
     /// Organizes RandomizerTags present in the scene
     /// </summary>
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Randomizers")]
     public class RandomizerTagManager
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/FloatRange.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/FloatRange.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Assert = UnityEngine.Assertions.Assert;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Samplers
+namespace UnityEngine.Perception.Randomization.Samplers
 {
     /// <summary>
     /// A struct representing a continuous range of values

--- a/com.unity.perception/Runtime/Randomization/Samplers/FloatRange.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/FloatRange.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine.Scripting.APIUpdating;
 using Assert = UnityEngine.Assertions.Assert;
 
 namespace UnityEngine.Perception.Randomization.Samplers
@@ -7,6 +8,7 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// A struct representing a continuous range of values
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public struct FloatRange
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/ISampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/ISampler.cs
@@ -1,7 +1,7 @@
 using System;
 using UnityEngine;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Samplers
+namespace UnityEngine.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Generates random values from probability distributions

--- a/com.unity.perception/Runtime/Randomization/Samplers/ISampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/ISampler.cs
@@ -1,11 +1,13 @@
 using System;
 using UnityEngine;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Generates random values from probability distributions
     /// </summary>
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public interface ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerState.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerState.cs
@@ -1,4 +1,4 @@
-﻿namespace UnityEngine.Experimental.Perception.Randomization.Samplers
+﻿namespace UnityEngine.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Encapsulates the random state that all samplers mutate when generating random values

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/AnimationCurveSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/AnimationCurveSampler.cs
@@ -4,9 +4,9 @@ using Unity.Burst;
 using Unity.Collections;
 using Unity.Collections.LowLevel.Unsafe;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Scenarios;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Samplers
+namespace UnityEngine.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Returns random values according to a range and probability distribution denoted by a user provided AnimationCurve.

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/AnimationCurveSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/AnimationCurveSampler.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Collections.LowLevel.Unsafe;
-using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Scenarios;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Samplers
 {
@@ -16,6 +11,7 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// The Y values cannot however be negative.
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public class AnimationCurveSampler : ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
@@ -3,7 +3,7 @@ using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Samplers
+namespace UnityEngine.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Returns a constant value when sampled

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Jobs;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Samplers
 {
@@ -9,6 +7,7 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// Returns a constant value when sampled
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public class ConstantSampler : ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Jobs;
-using UnityEngine.Perception.Randomization.Scenarios;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Samplers
 {
@@ -11,6 +8,7 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// https://en.wikipedia.org/wiki/Truncated_normal_distribution
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public class NormalSampler : ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
@@ -2,9 +2,9 @@
 using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Scenarios;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Samplers
+namespace UnityEngine.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Returns normally distributed random values bounded within a specified range

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
@@ -3,9 +3,9 @@ using Unity.Burst;
 using Unity.Collections;
 using Unity.Jobs;
 using Unity.Mathematics;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Scenarios;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Samplers
+namespace UnityEngine.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Returns uniformly distributed random values within a designated range.

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
@@ -1,9 +1,5 @@
 ﻿using System;
-using Unity.Burst;
-using Unity.Collections;
-using Unity.Jobs;
-using Unity.Mathematics;
-using UnityEngine.Perception.Randomization.Scenarios;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Samplers
 {
@@ -11,6 +7,7 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// Returns uniformly distributed random values within a designated range.
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public class UniformSampler : ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 using Unity.Collections;
 using Unity.Mathematics;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Samplers
+namespace UnityEngine.Perception.Randomization.Samplers
 {
     /// <summary>
     /// A set of utility functions for defining sampler interfaces

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerValidationException.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerValidationException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Samplers
+namespace UnityEngine.Perception.Randomization.Samplers
 {
     class SamplerValidationException : Exception
     {

--- a/com.unity.perception/Runtime/Randomization/Scenarios/FixedLengthScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/FixedLengthScenario.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -6,6 +7,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// A scenario that runs for a fixed number of frames during each iteration
     /// </summary>
     [AddComponentMenu("Perception/Randomization/Scenarios/Fixed Length Scenario")]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public class FixedLengthScenario: UnitySimulationScenario<FixedLengthScenario.Constants>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/FixedLengthScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/FixedLengthScenario.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
+namespace UnityEngine.Perception.Randomization.Scenarios
 {
     /// <summary>
     /// A scenario that runs for a fixed number of frames during each iteration

--- a/com.unity.perception/Runtime/Randomization/Scenarios/Scenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/Scenario.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json.Linq;
 using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.Perception.Randomization.Randomizers;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -13,6 +14,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// The base class of scenarios with serializable constants
     /// </summary>
     /// <typeparam name="T">The type of scenario constants to serialize</typeparam>
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public abstract class Scenario<T> : ScenarioBase where T : ScenarioConstants, new()
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/Scenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/Scenario.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
+namespace UnityEngine.Perception.Randomization.Scenarios
 {
     /// <summary>
     /// The base class of scenarios with serializable constants

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -7,6 +7,7 @@ using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.Perception.Randomization.Randomizers;
 using UnityEngine.Perception.Randomization.Samplers;
 using UnityEngine.Perception.GroundTruth;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -14,6 +15,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// Derive ScenarioBase to implement a custom scenario
     /// </summary>
     [DefaultExecutionOrder(-1)]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public abstract class ScenarioBase : MonoBehaviour
     {
         static ScenarioBase s_ActiveScenario;

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using Unity.Simulation;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Samplers;
 using UnityEngine.Perception.GroundTruth;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
+namespace UnityEngine.Perception.Randomization.Scenarios
 {
     /// <summary>
     /// Derive ScenarioBase to implement a custom scenario

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioConstants.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioConstants.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
+namespace UnityEngine.Perception.Randomization.Scenarios
 {
     /// <summary>
     /// The base class for implementing custom scenario constants classes

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioConstants.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioConstants.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -7,6 +8,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// The base class for implementing custom scenario constants classes
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public class ScenarioConstants
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioException.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
+namespace UnityEngine.Perception.Randomization.Scenarios
 {
     [Serializable]
     class ScenarioException : Exception

--- a/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenario.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Unity.Simulation;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -7,6 +8,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// Defines a scenario that is compatible with the Run in Unity Simulation window
     /// </summary>
     /// <typeparam name="T">The type of constants to serialize</typeparam>
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public abstract class UnitySimulationScenario<T> : Scenario<T> where T : UnitySimulationScenarioConstants, new()
     {
         /// <inheritdoc/>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenario.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Unity.Simulation;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
+namespace UnityEngine.Perception.Randomization.Scenarios
 {
     /// <summary>
     /// Defines a scenario that is compatible with the Run in Unity Simulation window

--- a/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenarioConstants.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenarioConstants.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace UnityEngine.Experimental.Perception.Randomization.Scenarios
+namespace UnityEngine.Perception.Randomization.Scenarios
 {
     /// <summary>
     /// A class encapsulating the scenario constants fields required for Unity Simulation cloud execution

--- a/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenarioConstants.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenarioConstants.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -6,6 +7,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// A class encapsulating the scenario constants fields required for Unity Simulation cloud execution
     /// </summary>
     [Serializable]
+    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public class UnitySimulationScenarioConstants : ScenarioConstants
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Unity.Perception.Runtime.asmdef
+++ b/com.unity.perception/Runtime/Unity.Perception.Runtime.asmdef
@@ -9,17 +9,15 @@
         "Unity.RenderPipelines.Core.Runtime",
         "Unity.RenderPipelines.HighDefinition.Runtime",
         "Unity.RenderPipelines.Universal.Runtime",
-        "Unity.Simulation.Core",
         "Unity.Simulation.Capture",
-        "PathCreator"
+        "Unity.Simulation.Core"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": true,
     "overrideReferences": true,
     "precompiledReferences": [
-        "Newtonsoft.Json.dll",
-        "QuickGraph.dll"
+        "Newtonsoft.Json.dll"
     ],
     "autoReferenced": true,
     "defineConstraints": [],

--- a/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
+++ b/com.unity.perception/Tests/Editor/RandomizerEditorTests.cs
@@ -1,8 +1,8 @@
 using System;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Scenarios;
 using Object = UnityEngine.Object;
 
 namespace EditorTests

--- a/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/CategoricalParameterTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/CategoricalParameterTests.cs
@@ -1,6 +1,6 @@
 ﻿using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Parameters;
 
 namespace RandomizationTests.ParameterTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/GenericParameterTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/GenericParameterTests.cs
@@ -1,6 +1,6 @@
 ﻿using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Parameters;
 
 namespace RandomizationTests.ParameterTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/StructParameterTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ParameterTests/StructParameterTests.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Scenarios;
 using Object = UnityEngine.Object;
 
 namespace RandomizationTests.ParameterTests

--- a/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/ExampleTransformRandomizer.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/ExampleTransformRandomizer.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using Unity.Mathematics;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Parameters;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Parameters;
+using UnityEngine.Perception.Randomization.Randomizers;
 
 namespace RandomizationTests.RandomizerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/RandomizerTagTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/RandomizerTagTests.cs
@@ -1,8 +1,8 @@
 ﻿using System.Linq;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Randomizers;
+using UnityEngine.Perception.Randomization.Scenarios;
 using Assert = Unity.Assertions.Assert;
 
 namespace RandomizationTests.RandomizerTests

--- a/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/RandomizerTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/RandomizerTests/RandomizerTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Scenarios;
 using UnityEngine.TestTools;
 
 namespace RandomizationTests.RandomizerTests

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/AnimationCurveSamplerTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/AnimationCurveSamplerTests.cs
@@ -1,5 +1,5 @@
 ﻿using NUnit.Framework;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/ConstantSamplerTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/ConstantSamplerTests.cs
@@ -1,5 +1,5 @@
 ﻿using NUnit.Framework;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/FloatRangeTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/FloatRangeTests.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/NormalSamplerTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/NormalSamplerTests.cs
@@ -1,5 +1,5 @@
 ﻿using NUnit.Framework;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/SamplerTestsBase.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/SamplerTestsBase.cs
@@ -2,8 +2,8 @@
 using NUnit.Framework;
 using Unity.Jobs;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Scenarios;
 using Object = UnityEngine.Object;
 
 namespace RandomizationTests.SamplerTests

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/SamplerUtilityTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/SamplerUtilityTests.cs
@@ -1,5 +1,5 @@
 ﻿using NUnit.Framework;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/UniformSamplerTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/SamplerTests/UniformSamplerTests.cs
@@ -1,5 +1,5 @@
 ﻿using NUnit.Framework;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Samplers;
 
 namespace RandomizationTests.SamplerTests
 {

--- a/com.unity.perception/Tests/Runtime/Randomization/ScenarioTests.cs
+++ b/com.unity.perception/Tests/Runtime/Randomization/ScenarioTests.cs
@@ -3,10 +3,10 @@ using System.Collections;
 using System.IO;
 using NUnit.Framework;
 using UnityEngine;
-using UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers;
-using UnityEngine.Experimental.Perception.Randomization.Samplers;
+using UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers;
+using UnityEngine.Perception.Randomization.Samplers;
 using UnityEngine.Perception.GroundTruth;
-using UnityEngine.Experimental.Perception.Randomization.Scenarios;
+using UnityEngine.Perception.Randomization.Scenarios;
 using UnityEngine.TestTools;
 using Object = UnityEngine.Object;
 


### PR DESCRIPTION
# Peer Review Information:
This PR removes the randomization tooling from the experimental namespace.

Note: I noticed that we include some references to assemblies that are no longer present in the perception package (PathCreator and QuickGraph) so I used this PR as an opportunity to remove them. I also sorted the order of the existing asmdef references while playing with Rider's "Sort Lines" code editing feature.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated docs
- [X] - Updated changelog
