### PR TITLE
Enabled GPU instancing on sample material

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -85,6 +85,8 @@ Categorical Parameters no longer produce errors when deleting items from long op
 
 Parameter, ISampler, and non-generic Sampler class UIs now render properly in MonoBehaviours and ScriptableObjects.
 
+Fixed an issue in the perception tutorial sample assets where upon the editor being first opened, and a user generates a dataset by clicking the play button, the first generated image has duplicated textures and hue offsets for all background objects. Enabling the "GPU instancing" boolean in the tutorial's sample material's inspector fixed this issue.
+
 ## [0.6.0-preview.1] - 2020-12-03
 
 ### Added

--- a/com.unity.perception/Samples~/Tutorial Files/Background Objects/Materials/prototyping_texture_alignment_01.mat
+++ b/com.unity.perception/Samples~/Tutorial Files/Background Objects/Materials/prototyping_texture_alignment_01.mat
@@ -9,9 +9,9 @@ Material:
   m_PrefabAsset: {fileID: 0}
   m_Name: prototyping_texture_alignment_01
   m_Shader: {fileID: -6465566751694194690, guid: 90ad3a47f8ccd406eab0fbf0c7a64d88, type: 3}
-  m_ShaderKeywords: 
+  m_ShaderKeywords:
   m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
+  m_EnableInstancingVariants: 1
   m_DoubleSidedGI: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
@@ -93,6 +93,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   version: 1


### PR DESCRIPTION
# Peer Review Information:
This PR enables the "GPU instancing" boolean in the sample material's inspector to fix a data generation bug in the perception tutorial. When the editor is first opened, and a user generates a dataset by clicking the play button, the first generated image had duplicated textures and hue offsets for all background objects.

![image](https://user-images.githubusercontent.com/53197518/106400908-d8736080-63e6-11eb-9a9f-dd124d3a7d46.png)
![image](https://user-images.githubusercontent.com/53197518/106400909-dc9f7e00-63e6-11eb-9e1c-e52b1f1dcbf5.png)

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
