### PR TITLE
Remove MovedFrom attribute for the Experimental namespace

### DIFF
--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -10,7 +9,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// </summary>
     /// <typeparam name="T">The sample type of the categorical parameter</typeparam>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public abstract class CategoricalParameter<T> : CategoricalParameterBase
     {
         [SerializeField] internal bool uniform = true;

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameterBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameterBase.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -8,7 +7,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// The base class of CategoricalParameters.
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public abstract class CategoricalParameterBase : Parameter
     {
         [SerializeField] internal List<float> probabilities = new List<float>();

--- a/com.unity.perception/Runtime/Randomization/Parameters/NumericParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/NumericParameter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -8,7 +7,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// </summary>
     /// <typeparam name="T">The sample type of the parameter</typeparam>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public abstract class NumericParameter<T> : Parameter where T : struct
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/Parameter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -11,7 +10,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// randomizing simulations.
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public abstract class Parameter
     {
         [HideInInspector, SerializeField] internal bool collapsed;

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/AnimationClipParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/AnimationClipParameter.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -7,6 +6,5 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for animation clips
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class AnimationClipParameter : CategoricalParameter<AnimationClip> { }
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/GameObjectParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/GameObjectParameter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -7,6 +6,5 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating GameObject samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class GameObjectParameter : CategoricalParameter<GameObject> { }
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/MaterialParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/MaterialParameter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -7,6 +6,5 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating Material samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class MaterialParameter : CategoricalParameter<Material> {}
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/StringParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/StringParameter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -7,6 +6,5 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating string samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class StringParameter : CategoricalParameter<string> {}
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/Texture2DParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/CategorialParameters/Texture2DParameter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -7,6 +6,5 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating GameObject samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class Texture2DParameter : CategoricalParameter<Texture2D> { }
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/BooleanParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/BooleanParameter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -9,7 +8,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating boolean samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class BooleanParameter : NumericParameter<bool>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsva.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsva.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Unity.Mathematics;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -8,7 +7,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A struct representing the hue, saturation, value, and alpha components of a particular color
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public struct ColorHsva
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaCategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaCategoricalParameter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -7,6 +6,5 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating ColorHsva samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class ColorHsvaCategoricalParameter : CategoricalParameter<ColorHsva> { }
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorHsvaParameter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -9,7 +8,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating color samples using HSVA samplers
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class ColorHsvaParameter : NumericParameter<Color>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbCategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbCategoricalParameter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -7,6 +6,5 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A categorical parameter for generating RGBA color samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class ColorRgbCategoricalParameter : CategoricalParameter<Color> { }
 }

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/ColorParameters/ColorRgbParameter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -9,7 +8,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating RGBA color samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class ColorRgbParameter : NumericParameter<Color>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/FloatParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/FloatParameter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -9,7 +8,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating float samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class FloatParameter : NumericParameter<float>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/IntegerParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/IntegerParameter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -9,7 +8,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating integer samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class IntegerParameter : NumericParameter<int>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector2Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector2Parameter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -9,7 +8,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating Vector2 samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class Vector2Parameter : NumericParameter<Vector2>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector3Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector3Parameter.cs
@@ -1,15 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
-
 namespace UnityEngine.Perception.Randomization.Parameters
 {
     /// <summary>
     /// A numeric parameter for generating Vector3 samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class Vector3Parameter : NumericParameter<Vector3>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector4Parameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/ParameterTypes/NumericParameters/Vector4Parameter.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Parameters
 {
@@ -9,7 +8,6 @@ namespace UnityEngine.Perception.Randomization.Parameters
     /// A numeric parameter for generating Vector4 samples
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Parameters")]
     public class Vector4Parameter : NumericParameter<Vector4>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Randomizers/AddRandomizerMenuAttribute.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/AddRandomizerMenuAttribute.cs
@@ -1,12 +1,10 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Randomizers
 {
     /// <summary>
     /// The AddRandomizerMenu attribute allows you to organize randomizers under different menu paths
     /// </summary>
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Randomizers")]
     public class AddRandomizerMenuAttribute : Attribute
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Randomizers/Randomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/Randomizer.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.Perception.Randomization.Scenarios;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Randomizers
 {
@@ -14,7 +13,6 @@ namespace UnityEngine.Perception.Randomization.Randomizers
     /// https://issuetracker.unity3d.com/issues/serializereference-non-serialized-initialized-fields-lose-their-values-when-entering-play-mode
     /// </remark>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Randomizers")]
     public abstract class Randomizer
     {
         bool m_PreviouslyEnabled;

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
@@ -10,7 +10,6 @@ namespace UnityEngine.Perception.Randomization.Randomizers.Utilities
     /// <summary>
     /// Utility for generating lists of poisson disk sampled points
     /// </summary>
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Randomizers.SampleRandomizers")]
     public static class PoissonDiskSampling
     {
         const int k_DefaultSamplingResolution = 30;

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Randomizers
 {
@@ -8,7 +7,6 @@ namespace UnityEngine.Perception.Randomization.Randomizers
     /// RandomizerTags are used to help randomizers query for a set of GameObjects to randomize.
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Randomizers")]
     public abstract class RandomizerTag : MonoBehaviour
     {
         RandomizerTagManager tagManager => RandomizerTagManager.singleton;

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTagManager.cs
@@ -1,13 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Randomizers
 {
     /// <summary>
     /// Organizes RandomizerTags present in the scene
     /// </summary>
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Randomizers")]
     public class RandomizerTagManager
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/FloatRange.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/FloatRange.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 using Assert = UnityEngine.Assertions.Assert;
 
 namespace UnityEngine.Perception.Randomization.Samplers
@@ -8,7 +7,6 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// A struct representing a continuous range of values
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public struct FloatRange
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/ISampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/ISampler.cs
@@ -1,13 +1,11 @@
 using System;
 using UnityEngine;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Samplers
 {
     /// <summary>
     /// Generates random values from probability distributions
     /// </summary>
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public interface ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/AnimationCurveSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/AnimationCurveSampler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Samplers
 {
@@ -11,7 +10,6 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// The Y values cannot however be negative.
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public class AnimationCurveSampler : ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Samplers
 {
@@ -7,7 +6,6 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// Returns a constant value when sampled
     /// </summary>
     [Serializable]
-
     public class ConstantSampler : ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/ConstantSampler.cs
@@ -7,7 +7,7 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// Returns a constant value when sampled
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
+
     public class ConstantSampler : ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/NormalSampler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Samplers
 {
@@ -8,7 +7,6 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// https://en.wikipedia.org/wiki/Truncated_normal_distribution
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public class NormalSampler : ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerTypes/UniformSampler.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Samplers
 {
@@ -7,7 +6,6 @@ namespace UnityEngine.Perception.Randomization.Samplers
     /// Returns uniformly distributed random values within a designated range.
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Samplers")]
     public class UniformSampler : ISampler
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/FixedLengthScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/FixedLengthScenario.cs
@@ -1,5 +1,4 @@
 using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -7,7 +6,6 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// A scenario that runs for a fixed number of frames during each iteration
     /// </summary>
     [AddComponentMenu("Perception/Randomization/Scenarios/Fixed Length Scenario")]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public class FixedLengthScenario: UnitySimulationScenario<FixedLengthScenario.Constants>
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/Scenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/Scenario.cs
@@ -6,7 +6,6 @@ using Newtonsoft.Json.Linq;
 using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.Perception.Randomization.Randomizers;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -14,7 +13,6 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// The base class of scenarios with serializable constants
     /// </summary>
     /// <typeparam name="T">The type of scenario constants to serialize</typeparam>
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public abstract class Scenario<T> : ScenarioBase where T : ScenarioConstants, new()
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -7,7 +7,6 @@ using UnityEngine.Perception.Randomization.Parameters;
 using UnityEngine.Perception.Randomization.Randomizers;
 using UnityEngine.Perception.Randomization.Samplers;
 using UnityEngine.Perception.GroundTruth;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -15,7 +14,6 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// Derive ScenarioBase to implement a custom scenario
     /// </summary>
     [DefaultExecutionOrder(-1)]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public abstract class ScenarioBase : MonoBehaviour
     {
         static ScenarioBase s_ActiveScenario;

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioConstants.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioConstants.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using UnityEngine.Perception.Randomization.Samplers;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -8,7 +7,6 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// The base class for implementing custom scenario constants classes
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public class ScenarioConstants
     {
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenario.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Unity.Simulation;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -8,7 +7,6 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// Defines a scenario that is compatible with the Run in Unity Simulation window
     /// </summary>
     /// <typeparam name="T">The type of constants to serialize</typeparam>
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public abstract class UnitySimulationScenario<T> : Scenario<T> where T : UnitySimulationScenarioConstants, new()
     {
         /// <inheritdoc/>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenarioConstants.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenarioConstants.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using UnityEngine.Scripting.APIUpdating;
 
 namespace UnityEngine.Perception.Randomization.Scenarios
 {
@@ -7,7 +6,6 @@ namespace UnityEngine.Perception.Randomization.Scenarios
     /// A class encapsulating the scenario constants fields required for Unity Simulation cloud execution
     /// </summary>
     [Serializable]
-    [MovedFrom("UnityEngine.Experimental.Perception.Randomization.Scenarios")]
     public class UnitySimulationScenarioConstants : ScenarioConstants
     {
         /// <summary>


### PR DESCRIPTION
# Peer Review Information:
In case we need decide to remove the MovedFrom attribute, here's a PR that does just that.

## Editor / Package versioning:
**Editor Version Target**: 2019.4
