### PR TITLE
Fix Post State Configs not showing up in 2019.4

### DIFF
--- a/com.unity.perception/Editor/GroundTruth/CameraLabelerDrawer.cs
+++ b/com.unity.perception/Editor/GroundTruth/CameraLabelerDrawer.cs
@@ -99,8 +99,9 @@ namespace UnityEditor.Perception.GroundTruth {
         {
             foreach (var prop in m_LabelerUserProperties)
             {
-                EditorGUI.PropertyField(rect, prop);
-                rect.y += Styles.defaultLineSpace;
+                EditorGUI.PropertyField(rect, prop, true);
+                var height = EditorGUI.GetPropertyHeight(prop) + EditorGUIUtility.standardVerticalSpacing;
+                rect.y += height;
             }
         }
 


### PR DESCRIPTION
# Peer Review Information:
This fixes Pose State Config not showing up in the editor in 2019.4. The fix was to use an overload of `EditorGUI.PropertyField` that enables drawing children (not sure why this isn't default). The reason it only occurs on 2019.4 is that the default editor for arrays changed in 2020 to a nicer control which apparently does not respect this child drawing flag.
![image](https://user-images.githubusercontent.com/23556416/106823829-73ae4500-6636-11eb-9cd2-419dd27a66c7.png)


## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.4

## Dev Testing:
**Tests Added**: None. GUI work.

**Core Scenario Tested**: Tested the UI on 2019.4 and 2020.2

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
