### PR TITLE
Upgrade capture dependencies

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -89,6 +89,8 @@ The uniform toggle on Categorical Parameters will now reset the Parameter's prob
 
 Reorganized Perception MonoBehaviour paths within the AddComponentMenu.
 
+Upgraded the Unity Simulation Capture package dependency to 0.0.10-preview.18 and Unity Simulation Core to 0.0.10-preview.22
+
 ### Deprecated
 
 ### Removed

--- a/com.unity.perception/package.json
+++ b/com.unity.perception/package.json
@@ -5,8 +5,8 @@
     "com.unity.burst": "1.3.9",
     "com.unity.entities": "0.8.0-preview.8",
     "com.unity.simulation.client": "0.0.10-preview.10",
-    "com.unity.simulation.capture": "0.0.10-preview.16",
-    "com.unity.simulation.core": "0.0.10-preview.21"
+    "com.unity.simulation.capture": "0.0.10-preview.18",
+    "com.unity.simulation.core": "0.0.10-preview.22"
   },
   "description": "Tools for generating large-scale data sets for perception-based machine learning training and validation",
   "displayName": "Perception",


### PR DESCRIPTION
# Peer Review Information:
This PR upgrades the Unity Simulation Capture package dependency to 0.0.10-preview.18 and Unity Simulation Core to 0.0.10-preview.22

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
