### PR TITLE
Fixed Unity Simulation per instance iteration offset

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+Fixed the math offsetting the iteration index of each Unity Simulation instance directly after they deserialize their app-params
+
 ## [0.7.0-preview.1] - 2021-02-01
 
 ### Upgrade Notes

--- a/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/UnitySimulationScenario.cs
@@ -30,7 +30,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios
         public sealed override void DeserializeFromFile(string configFilePath)
         {
             base.DeserializeFromFile(configFilePath);
-            currentIteration = constants.instanceIndex * constants.instanceCount;
+            currentIteration = constants.instanceIndex;
         }
     }
 }


### PR DESCRIPTION
# Peer Review Information:
This PR corrects the math offsetting the iteration index of each Unity Simulation instance directly after they deserialize their app-params.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
