### PR TITLE
Fix multiple cameras

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+Fixed ground truth not properly produced when there are other disabled PerceptionCameras present. Note: this does not yet add support for multiple enabled PerceptionCameras.
+
 ## [0.7.0-preview.2] - 2021-02-08
 
 ### Upgrade Notes

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
@@ -33,14 +33,14 @@ namespace UnityEngine.Perception.GroundTruth
         internal bool m_fLensDistortionEnabled = false;
 
 #if HDRP_PRESENT || URP_PRESENT
+        private float? m_LensDistortionIntensityOverride;
     #if HDRP_PRESENT
         InstanceSegmentationPass m_InstanceSegmentationPass;
         LensDistortionPass m_LensDistortionPass;
-#elif URP_PRESENT
+    #elif URP_PRESENT
         InstanceSegmentationUrpPass m_InstanceSegmentationPass;
         LensDistortionUrpPass m_LensDistortionPass;
     #endif
-        private float? m_LensDistortionIntensityOverride;
 
         internal void OverrideLensDistortionIntensity(float? intensity)
         {
@@ -61,6 +61,7 @@ namespace UnityEngine.Perception.GroundTruth
 
             m_RenderedObjectInfoGenerator = new RenderedObjectInfoGenerator();
 
+#if HDRP_PRESENT || URP_PRESENT
 #if HDRP_PRESENT
             var customPassVolume = this.GetComponent<CustomPassVolume>() ?? gameObject.AddComponent<CustomPassVolume>();
             customPassVolume.injectionPoint = CustomPassInjectionPoint.BeforeRendering;
@@ -95,6 +96,7 @@ namespace UnityEngine.Perception.GroundTruth
 #endif
             m_LensDistortionPass.m_LensDistortionCrossPipelinePass.lensDistortionOverride =
                 m_LensDistortionIntensityOverride;
+#endif
 
             m_InstanceSegmentationReader = new RenderTextureReader<Color32>(m_InstanceSegmentationTexture, myCamera, (frameCount, data, tex) =>
             {

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera_InstanceSegmentation.cs
@@ -36,14 +36,17 @@ namespace UnityEngine.Perception.GroundTruth
     #if HDRP_PRESENT
         InstanceSegmentationPass m_InstanceSegmentationPass;
         LensDistortionPass m_LensDistortionPass;
-    #elif URP_PRESENT
+#elif URP_PRESENT
         InstanceSegmentationUrpPass m_InstanceSegmentationPass;
         LensDistortionUrpPass m_LensDistortionPass;
     #endif
+        private float? m_LensDistortionIntensityOverride;
 
         internal void OverrideLensDistortionIntensity(float? intensity)
         {
-            m_LensDistortionPass.m_LensDistortionCrossPipelinePass.lensDistortionOverride = intensity;
+            m_LensDistortionIntensityOverride = intensity;
+            if (m_LensDistortionPass != null)
+                m_LensDistortionPass.m_LensDistortionCrossPipelinePass.lensDistortionOverride = intensity;
         }
 #endif
 
@@ -90,6 +93,8 @@ namespace UnityEngine.Perception.GroundTruth
 
             m_fLensDistortionEnabled = true;
 #endif
+            m_LensDistortionPass.m_LensDistortionCrossPipelinePass.lensDistortionOverride =
+                m_LensDistortionIntensityOverride;
 
             m_InstanceSegmentationReader = new RenderTextureReader<Color32>(m_InstanceSegmentationTexture, myCamera, (frameCount, data, tex) =>
             {

--- a/com.unity.perception/Tests/Editor/PerceptionCameraEditorTests.cs
+++ b/com.unity.perception/Tests/Editor/PerceptionCameraEditorTests.cs
@@ -22,15 +22,14 @@ namespace EditorTests
         public IEnumerator EditorPause_DoesNotLogErrors()
         {
             ResetScene();
-            PerceptionCamera perceptionCamera = null;
-            SetupCamera(p =>
+            var cameraObject = SetupCamera(p =>
             {
                 var idLabelConfig = ScriptableObject.CreateInstance<IdLabelConfig>();
                 p.captureRgbImages = true;
                 p.AddLabeler(new BoundingBox2DLabeler(idLabelConfig));
                 p.AddLabeler(new RenderedObjectInfoLabeler(idLabelConfig));
-                perceptionCamera = p;
             });
+            cameraObject.name = "Camera";
             yield return new EnterPlayMode();
             var expectedFirstFrame = Time.frameCount;
             yield return null;
@@ -50,7 +49,7 @@ namespace EditorTests
             var capturesJson = File.ReadAllText(capturesPath);
             for (int iFrameCount = expectedFirstFrame; iFrameCount <= expectedLastFrame; iFrameCount++)
             {
-                var imagePath = $"{perceptionCamera.rgbDirectory}/rgb_{iFrameCount}";
+                var imagePath = $"{GameObject.Find("Camera").GetComponent<PerceptionCamera>().rgbDirectory}/rgb_{iFrameCount}";
                 StringAssert.Contains(imagePath, capturesJson);
             }
 

--- a/com.unity.perception/Tests/Editor/PerceptionCameraEditorTests.cs
+++ b/com.unity.perception/Tests/Editor/PerceptionCameraEditorTests.cs
@@ -22,12 +22,14 @@ namespace EditorTests
         public IEnumerator EditorPause_DoesNotLogErrors()
         {
             ResetScene();
+            PerceptionCamera perceptionCamera = null;
             SetupCamera(p =>
             {
                 var idLabelConfig = ScriptableObject.CreateInstance<IdLabelConfig>();
                 p.captureRgbImages = true;
                 p.AddLabeler(new BoundingBox2DLabeler(idLabelConfig));
                 p.AddLabeler(new RenderedObjectInfoLabeler(idLabelConfig));
+                perceptionCamera = p;
             });
             yield return new EnterPlayMode();
             var expectedFirstFrame = Time.frameCount;
@@ -48,7 +50,7 @@ namespace EditorTests
             var capturesJson = File.ReadAllText(capturesPath);
             for (int iFrameCount = expectedFirstFrame; iFrameCount <= expectedLastFrame; iFrameCount++)
             {
-                var imagePath = $"{PerceptionCamera.RgbDirectory}/rgb_{iFrameCount}";
+                var imagePath = $"{perceptionCamera.rgbDirectory}/rgb_{iFrameCount}";
                 StringAssert.Contains(imagePath, capturesJson);
             }
 

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/VisualizationTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/VisualizationTests.cs
@@ -59,8 +59,8 @@ namespace GroundTruthTests
 
             Assert.IsNotNull(GameObject.Find("overlay_canvas"));
         }
-        [Test]
-        public void TwoCamerasVisualizing_CausesWarningAndDisablesVisualization()
+        [UnityTest]
+        public IEnumerator TwoCamerasVisualizing_CausesWarningAndDisablesVisualization()
         {
             var object1 = new GameObject();
             object1.name = nameof(TwoCamerasVisualizing_CausesWarningAndDisablesVisualization);
@@ -79,8 +79,11 @@ namespace GroundTruthTests
             AddTestObjectForCleanup(object2);
 
             object1.SetActive(true);
+            yield return null;
             LogAssert.Expect(LogType.Warning, $"Currently only one PerceptionCamera may be visualized at a time. Disabling visualization on {nameof(TwoCamerasVisualizing_CausesWarningAndDisablesVisualization)}2.");
+            LogAssert.ignoreFailingMessages = true;
             object2.SetActive(true);
+            yield return null;
         }
         [UnityTest]
         public IEnumerator DestroyCamera_RemovesVisualization()


### PR DESCRIPTION
# Peer Review Information:
Fixes bug reported by ANT where disabled PerceptionCameras cause the active PerceptionCamera to not produce proper 2d bounding boxes in HDRP.

The reason was our in our use of CustomPasses. Only one CustomPass of a given type may run at any one time, and since CustomPasses were initialized in PerceptionCamera.Awake(), the disabled PerceptionCameras' CustomPasses were overwriting the enabled one. This is a bigger issue to be addressed when we go to properly support multiple simultaneous cameras. This fix moves the initialization logic from Awake into Start to address the immediate issue with disabled PerceptionCameras.

A few other changes needed to be made to adjust for the timing of the logic. In the process I made RGB capture work for multiple cameras at once to resolve a new test failure.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.4

## Dev Testing:
**Tests Added**: Added new test. Updated existing tests as needed.

**Core Scenario Tested**: Tested the core scenario in HDRP 2019.4

**At Risk Areas**: Ground truth rendering

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [x] - Updated changelog
