### PR TITLE
Fixed categorical parameter uniform toggle issues in HDRP

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+Fixed a null reference error that appeared when adding options to categorical parameters.
+
 Fixed ground truth not properly produced when there are other disabled PerceptionCameras present. Note: this does not yet add support for multiple enabled PerceptionCameras.
 
 ## [0.7.0-preview.2] - 2021-02-08

--- a/com.unity.perception/Editor/Randomization/Uss/Styles.uss
+++ b/com.unity.perception/Editor/Randomization/Uss/Styles.uss
@@ -139,6 +139,10 @@
     flex-shrink: 0;
 }
 
+.parameter__categorical-option-property-field Label.unity-property-field__label {
+    display: none;
+}
+
 .parameter__categorical-options-list-button {
     align-self: flex-end;
     border-width: 0;

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter/CategoricalOptionElement.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter/CategoricalOptionElement.cs
@@ -7,8 +7,8 @@ namespace UnityEditor.Perception.Randomization
 {
     class CategoricalOptionElement : VisualElement
     {
-        SerializedProperty m_CategoryProperty;
         int m_Index;
+        SerializedProperty m_CategoryProperty;
         SerializedProperty m_ProbabilitiesProperty;
 
         internal CategoricalOptionElement(
@@ -35,10 +35,6 @@ namespace UnityEditor.Perception.Randomization
             var optionProperty = m_CategoryProperty.GetArrayElementAtIndex(i);
             var option = this.Q<PropertyField>("option");
             option.BindProperty(optionProperty);
-
-            // Remove the redundant element label to save space
-            var label = option.Q<Label>();
-            label.parent.Remove(label);
 
             var probabilityProperty = m_ProbabilitiesProperty.GetArrayElementAtIndex(i);
             var probability = this.Q<FloatField>("probability");

--- a/com.unity.perception/Editor/Randomization/VisualElements/Parameter/ParameterElement.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Parameter/ParameterElement.cs
@@ -171,17 +171,21 @@ namespace UnityEditor.Perception.Randomization
             var uniformProperty = m_SerializedProperty.FindPropertyRelative("uniform");
             uniformToggle.BindProperty(uniformProperty);
 
-            if (uniformToggle.value)
-                listView.AddToClassList("collapsed");
-            else
-                listView.RemoveFromClassList("collapsed");
+            void ToggleUniform()
+            {
+                if (uniformToggle.value)
+                    listView.AddToClassList("collapsed");
+                else
+                    listView.RemoveFromClassList("collapsed");
+            }
+            ToggleUniform();
 
             if (Application.isPlaying)
                 uniformToggle.SetEnabled(false);
             else
                 uniformToggle.RegisterCallback<ChangeEvent<bool>>(evt =>
                 {
-                    listView.ToggleInClassList("collapsed");
+                    ToggleUniform();
                     if (!evt.newValue)
                         return;
                     var numOptions = optionsProperty.arraySize;


### PR DESCRIPTION
# Peer Review Information:
This PR fixes two issues with the uniform toggle on categorical parameters that were discovered in HDRP:
1. An null reference error was appearing when attempting to remove the extraneous label added to categorical option UI elements. This was fixed by using USS selectors instead of C# to style away labels instead of explicitly removing them.
2. The uniform toggle wasn't being initialized properly, causing it to toggle to the opposite state on occasion. This has been fixed by using a stateful approach to modifying the UI instead of a toggle approach.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
