### PR TITLE
Randomizer tags can be enabled via editor

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -33,6 +33,8 @@ ScenarioBase's Get and Create randomizer methods have been augmented or replaced
 
 The scenario inspector buttons serialize and deserialize have been refactored to open a file explorer generate and import JSON configurations.
 
+Randomizer tags now use OnEnable and OnDisable to manage lifecycle. This allows the user to toggle them on and off in the editor.
+
 ### Deprecated
 
 ### Removed

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
@@ -12,17 +12,18 @@ namespace UnityEngine.Perception.Randomization.Randomizers
         RandomizerTagManager tagManager => RandomizerTagManager.singleton;
 
         /// <summary>
-        /// Awake is called when this RandomizerTag is created or instantiated
+        /// OnEnable is called when this RandomizerTag is enabled, either created, instantiated, or enabled via
+        /// the Unity Editor
         /// </summary>
-        protected virtual void Awake()
+        protected void OnEnable()
         {
             Register();
         }
 
         /// <summary>
-        /// OnDestroy is called when this RandomizerTag is destroyed
+        /// OnDisable is called when this RandomizerTag is disabled
         /// </summary>
-        protected virtual void OnDestroy()
+        protected virtual void OnDisable()
         {
             Unregister();
         }


### PR DESCRIPTION
# Peer Review Information:
Changed randomizer tags to use OnEnable and OnDisable. This allows for the user to enable/disable them via a toggle in the Unity Editor. Tested and verified that this works before game play and during game play.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [x] - Updated docs
- [x] - Updated changelog
