### PR TITLE
Keypoint occlusion

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -25,7 +25,9 @@ If a labeled asset is at least partially visible all keypoints will be annotated
 1: Exists in model and in camera's frustum but occluded by another object<br>
 2: On screen and visible.
 
-New keypoint tests have been added to test keypoint state
+New keypoint tests have been added to test keypoint state.
+
+The color of keypoints and connections are now reported in the annotation definition json file for keypoint templates.
 
 ### Changed
 

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -20,10 +20,6 @@ Scenario serialization has been updated to include scalar values on randomizers 
 Added new ScenarioBase virtual lifecycle hooks: OnAwake, OnStart, OnComplete, and OnIdle.
 
 Keypoint occlusion has been added, no keypoint information will be recorded for a labeled asset completely out of the camera's frustum. 
-If a labeled asset is at least partially visible all keypoints will be annotated with the following state values:<br> 
-0: Off of screen or does not exist in model<br>
-1: Exists in model and in camera's frustum but occluded by another object<br>
-2: On screen and visible.
 
 New keypoint tests have been added to test keypoint state.
 

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -19,6 +19,14 @@ Scenario serialization has been updated to include scalar values on randomizers 
 
 Added new ScenarioBase virtual lifecycle hooks: OnAwake, OnStart, OnComplete, and OnIdle.
 
+Keypoint occlusion has been added, no keypoint information will be recorded for a labeled asset completely out of the camera's frustum. 
+If a labeled asset is at least partially visible all keypoints will be annotated with the following state values:<br> 
+0: Off of screen or does not exist in model<br>
+1: Exists in model and in camera's frustum but occluded by another object<br>
+2: On screen and visible.
+
+New keypoint tests have been added to test keypoint state
+
 ### Changed
 
 Renamed all appearances of the term `KeyPoint` within types and names to `Keypoint`.

--- a/com.unity.perception/Documentation~/Schema/Synthetic_Dataset_Schema.md
+++ b/com.unity.perception/Documentation~/Schema/Synthetic_Dataset_Schema.md
@@ -248,7 +248,8 @@ bounding_box_3d {
 
 Keypoint data, commonly used for human pose estimation. A keypoint capture is associated to a template that defines the keypoints (see annotation.definition file).
 Each keypoint record maps a tuple of (instance, label) to template, pose, and an array of keypoints. A keypoint will exist in this record for each keypoint defined in the template file.
-If a given keypoint doesn't exist in the labeled gameobject, then that keypoint will have a state value of 0; if it does exist then it will have a keypoint value of 2.
+If a given keypoint doesn't exist in the labeled gameobject, then that keypoint will have a state value of 0; if it exists but is not visible, it will have a state value of 1, 
+if it exists and is visible it will have a state value of 2.
 ```
 keypoints {
   label_id:      <int>   -- Integer identifier of the label
@@ -260,7 +261,7 @@ keypoints {
       index:     <int>   -- Index of keypoint in template
       x:         <float> -- X pixel coordinate of keypoint
       y:         <float> -- Y pixel coordinate of keypoint
-      state:     <int>   -- 0: keypoint does not exist, 2 keypoint exists
+      state:     <int>   -- 0: keypoint does not exist, 1 keypoint exists but is not visible, 2 keypoint exists and is visible
     }, ...
   ]
 }

--- a/com.unity.perception/Documentation~/Schema/Synthetic_Dataset_Schema.md
+++ b/com.unity.perception/Documentation~/Schema/Synthetic_Dataset_Schema.md
@@ -383,12 +383,24 @@ annotation_definition.spec {
     {
       label:         <str>           -- The label of the joint
       index:         <int>           -- The index of the joint
+      color {                        -- [Optional] The color to use for the visualization of the keypoint
+        r:           <float>         -- Value from 0 to 1 for the red channel
+        g:           <float>         -- Value from 0 to 1 for the green channel
+        b:           <float>         -- Value from 0 to 1 for the blue channel
+        a:           <float>         -- Value from 0 to 1 for the alpha channel
+      }
     }, ...
   ]
   skeleton [                         -- Array of skeletal connections (which joints have connections between one another) defined in this template
     {
       joint1:        <int>           -- The first joint of the connection
       joint2:        <int>           -- The second joint of the connection
+      color {                        -- [Optional] The color to use for the visualization of the bone
+        r:           <float>         -- Value from 0 to 1 for the red channel
+        g:           <float>         -- Value from 0 to 1 for the green channel
+        b:           <float>         -- Value from 0 to 1 for the blue channel
+        a:           <float>         -- Value from 0 to 1 for the alpha channel
+      }
     }, ...
   ]
 }

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/KeypointLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/KeypointLabeler.cs
@@ -463,6 +463,7 @@ namespace UnityEngine.Perception.GroundTruth
         {
             public string label;
             public int index;
+            public Color color;
         }
 
         [Serializable]
@@ -470,6 +471,7 @@ namespace UnityEngine.Perception.GroundTruth
         {
             public int joint1;
             public int joint2;
+            public Color color;
         }
 
         [Serializable]
@@ -496,7 +498,8 @@ namespace UnityEngine.Perception.GroundTruth
                 json.key_points[i] = new JointJson
                 {
                     label = input.keypoints[i].label,
-                    index = i
+                    index = i,
+                    color = input.keypoints[i].color
                 };
             }
 
@@ -505,7 +508,8 @@ namespace UnityEngine.Perception.GroundTruth
                 json.skeleton[i] = new SkeletonJson()
                 {
                     joint1 = input.skeleton[i].joint1,
-                    joint2 = input.skeleton[i].joint2
+                    joint2 = input.skeleton[i].joint2,
+                    color = input.skeleton[i].color
                 };
             }
 


### PR DESCRIPTION
# Peer Review Information:
Fixes for both 1160 & 1161. Labeled assets with all of their keypoints completely off screen are not reported to the captures.json file. If a labeled asset is at least partially on screen (or more precise at least 1 of its keypoints are on screen) then all the keypoints will be marked with the following values: 0 => keypoint does not exist in the model or is off screen, 1 => keypoint exists and is on screen, but is occluded by some other object, 2 => keypoint exists and is visible.

New correctness tests have been included to test all of these states.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [x] - Updated docs
- [x] - Updated changelog
