### PR TITLE
Remove code coverage generation from per-commit CI

### DIFF
--- a/.yamato/upm-ci-full.yml
+++ b/.yamato/upm-ci-full.yml
@@ -69,10 +69,7 @@ test_trigger:
     {% endfor %}
     {% endfor %}
     {% endfor %}
-
-    {% for editor in coverage_editors %}
-    - .yamato/upm-ci-testprojects.yml#codecoverage_windows_editmode_{{editor.version}}
-    {% endfor %}
+    
     {% for editor in per_commit_editors %}
     {% for project in projects %}
     - .yamato/upm-ci-testprojects.yml#{{project.name}}_windows_standalone_{{editor.version}}


### PR DESCRIPTION
# Peer Review Information:
Removing code coverage from per-commit tests. Code coverage fails from time to time, and it isn't necessary to run in the PR process since it is only used for manual checking of quality.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
