### PR TITLE
Cloud rendering support

### DIFF
--- a/com.unity.perception/Editor/Randomization/Editors/RunInUnitySimulationWindow.cs
+++ b/com.unity.perception/Editor/Randomization/Editors/RunInUnitySimulationWindow.cs
@@ -35,6 +35,8 @@ namespace UnityEditor.Perception.Randomization
         Label m_PrevExecutionIdLabel;
         RunParameters m_RunParameters;
 
+        private string supportedGPU = "NVIDIA";
+
         [MenuItem("Window/Run in Unity Simulation")]
         static void ShowWindow()
         {
@@ -166,6 +168,16 @@ namespace UnityEditor.Perception.Randomization
 
         async void RunInUnitySimulation()
         {
+            #if PLATFORM_CLOUD_RENDERING
+            if (!m_SysParamDefinitions[m_SysParamIndex].description.Contains(supportedGPU))
+            {
+                EditorUtility.DisplayDialog("Unsupported Sysparam",
+                    "The current selection of the Sysparam " + m_SysParamDefinitions[m_SysParamIndex].description +
+                    " is not supported " +
+                    "by this build target. Please select a sysparam with GPU", "Ok");
+                return;
+            }
+            #endif
             m_RunParameters = new RunParameters
             {
                 runName = m_RunNameField.value,
@@ -228,7 +240,11 @@ namespace UnityEditor.Perception.Randomization
             {
                 scenes = new[] { m_RunParameters.currentOpenScenePath },
                 locationPathName = Path.Combine(projectBuildDirectory, $"{m_RunParameters.runName}.x86_64"),
+#if PLATFORM_CLOUD_RENDERING
+                target = BuildTarget.CloudRendering,
+#else
                 target = BuildTarget.StandaloneLinux64
+#endif
             };
             var report = BuildPipeline.BuildPlayer(buildPlayerOptions);
             var summary = report.summary;

--- a/com.unity.perception/Editor/Randomization/Editors/RunInUnitySimulationWindow.cs
+++ b/com.unity.perception/Editor/Randomization/Editors/RunInUnitySimulationWindow.cs
@@ -173,8 +173,7 @@ namespace UnityEditor.Perception.Randomization
             {
                 EditorUtility.DisplayDialog("Unsupported Sysparam",
                     "The current selection of the Sysparam " + m_SysParamDefinitions[m_SysParamIndex].description +
-                    " is not supported " +
-                    "by this build target. Please select a sysparam with GPU", "Ok");
+                    " is not supported by this build target. Please select a sysparam with GPU", "Ok");
                 return;
             }
             #endif

--- a/com.unity.perception/Editor/Randomization/Editors/RunInUnitySimulationWindow.cs
+++ b/com.unity.perception/Editor/Randomization/Editors/RunInUnitySimulationWindow.cs
@@ -35,7 +35,7 @@ namespace UnityEditor.Perception.Randomization
         Label m_PrevExecutionIdLabel;
         RunParameters m_RunParameters;
 
-        private string supportedGPU = "NVIDIA";
+        const string  m_SupportedGPUString = "NVIDIA";
 
         [MenuItem("Window/Run in Unity Simulation")]
         static void ShowWindow()
@@ -169,7 +169,7 @@ namespace UnityEditor.Perception.Randomization
         async void RunInUnitySimulation()
         {
             #if PLATFORM_CLOUD_RENDERING
-            if (!m_SysParamDefinitions[m_SysParamIndex].description.Contains(supportedGPU))
+            if (!m_SysParamDefinitions[m_SysParamIndex].description.Contains(m_SupportedGPUString))
             {
                 EditorUtility.DisplayDialog("Unsupported Sysparam",
                     "The current selection of the Sysparam " + m_SysParamDefinitions[m_SysParamIndex].description +


### PR DESCRIPTION
# Peer Review Information:
Updated the RunInUnitySimulationWindow script to add support for cloudrendering build.
The changes will build for CloudRendering build target when the user is on that build target and check for sysparam selection.
It will prompt if the right sysparam is not selected by the developer (with GPU) from the dropdown.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
Verified locally by running simulation with cloudrendering build target.
Verfied the dialog with different sysparam selection

**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 
Unity Simulation Build and Run

**Notes + Expectations**: 
- When switched to cloud rendering build target, Build and Run option should create a headless build with cloud rendering build target.
- If appropriate sysparam is not selected, the editor should prompt a dialog for appropriate sysparam selection.

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
