### PR TITLE
Fixed a perception camera editor UI bug

### DIFF
--- a/com.unity.perception/Editor/GroundTruth/PerceptionCameraEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/PerceptionCameraEditor.cs
@@ -18,7 +18,7 @@ namespace UnityEditor.Perception.GroundTruth
 
         public void OnEnable()
         {
-            m_LabelersList = new ReorderableList(this.serializedObject, labelersProperty, true, false, true, true);
+            m_LabelersList = new ReorderableList(this.serializedObject, labelersProperty, true, true, true, true);
             m_LabelersList.drawHeaderCallback = (rect) =>
             {
                 EditorGUI.LabelField(rect, "Camera Labelers", EditorStyles.largeLabel);


### PR DESCRIPTION
# Peer Review Information:
Information on any code, feature, documentation changes here

The displayHeader flag was set to false for the list of labelers in PerceptionCamera. Weirdly, it was still displaying in older Unity versions before 2020.2.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
