### PR TITLE
Removed test error preventing Unity from playing

### DIFF
--- a/com.unity.perception/Tests/Editor/UIElementsEditorUtilitiesTests.cs
+++ b/com.unity.perception/Tests/Editor/UIElementsEditorUtilitiesTests.cs
@@ -4,6 +4,8 @@ using UnityEditor;
 using UnityEngine;
 using Object = UnityEngine.Object;
 
+// Disable value is never assigned to warning
+#pragma warning disable 649
 public class UIElementsEditorUtilitiesTests
 {
     //ScriptableObject so we can use ScriptableObject.CreateInstance()


### PR DESCRIPTION
# Peer Review Information:
A test has a warning about unused variable, pragma'ed it out

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
