### PR TITLE
Quick fix for a out of range error that could occur

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -65,6 +65,8 @@ Fixed a bug where uniform probabilities were not properly reset upon adding or r
 
 Fixed keypoints being reporeted in wrong locations on the first frame an object is visible.
 
+Fixed an out of range error if a keypoint template skeleton relies on a joint that is not available.
+
 ## [0.7.0-preview.2] - 2021-02-08
 
 ### Upgrade Notes

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/KeypointLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/KeypointLabeler.cs
@@ -418,6 +418,12 @@ namespace UnityEngine.Perception.GroundTruth
             return "unset";
         }
 
+        Keypoint GetKeypointForJoint(KeypointEntry entry, int joint)
+        {
+            if (joint < 0 || joint >= entry.keypoints.Length) return null;
+            return entry.keypoints[joint];
+        }
+
         /// <inheritdoc/>
         protected override void OnVisualize()
         {
@@ -433,10 +439,10 @@ namespace UnityEngine.Perception.GroundTruth
             {
                 foreach (var bone in activeTemplate.skeleton)
                 {
-                    var joint1 = entry.keypoints[bone.joint1];
-                    var joint2 = entry.keypoints[bone.joint2];
+                    var joint1 = GetKeypointForJoint(entry, bone.joint1);
+                    var joint2 = GetKeypointForJoint(entry, bone.joint2);
 
-                    if (joint1.state == 2 && joint2.state == 2)
+                    if (joint1 != null && joint1.state == 2 && joint2 != null && joint2.state == 2)
                     {
                         VisualizationHelper.DrawLine(joint1.x, joint1.y, joint2.x, joint2.y, bone.color, 8, skeletonTexture);
                     }


### PR DESCRIPTION
A quick fix for an index out of bounds error that could occur if a keypoint template file was not set up properly

# Peer Review Information:
Information on any code, feature, documentation changes here

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [x] - Updated docs
- [x] - Updated changelog
