### PR TITLE
Remove waits for 2x perf

### DIFF
--- a/com.unity.perception/Runtime/GroundTruth/Labelers/InstanceSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/InstanceSegmentationLabeler.cs
@@ -130,7 +130,7 @@ namespace UnityEngine.Perception.GroundTruth
                 m_InstancePath = $"{k_Directory}/{k_FilePrefix}{frameCount}.png";
                 var localPath = $"{Manager.Instance.GetDirectoryFor(k_Directory)}/{k_FilePrefix}{frameCount}.png";
 
-                var colors = new NativeArray<Color32>(data, Allocator.TempJob);
+                var colors = new NativeArray<Color32>(data, Allocator.Persistent);
 
                 var asyncRequest = Manager.Instance.CreateRequest<AsyncRequest<AsyncWrite>>();
 

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/SemanticSegmentationLabeler.cs
@@ -233,7 +233,7 @@ namespace UnityEngine.Perception.GroundTruth
             });
             asyncRequest.data = new AsyncSemanticSegmentationWrite
             {
-                data = new NativeArray<Color32>(data, Allocator.TempJob),
+                data = new NativeArray<Color32>(data, Allocator.Persistent),
                 width = targetTexture.width,
                 height = targetTexture.height,
                 path = localPath

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -192,9 +192,7 @@ namespace UnityEngine.Perception.GroundTruth
         {
             // Jobs are not chained to one another in any way, maximizing parallelism
             AsyncRequest.maxJobSystemParallelism = 0;
-
-            // Ensure that read-backs happen before Allocator.TempJob allocations get stale
-            AsyncRequest.maxAsyncRequestFrameAge = 4;
+            AsyncRequest.maxAsyncRequestFrameAge = 0;
 
             Application.runInBackground = true;
 


### PR DESCRIPTION
# Peer Review Information:
Remove AsyncRequest frame limiter to prevent hanging on image encoding in projects with little rendering and scene setup like SynthDet V2. Doubles frame rate in the editor in this case.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.4

## Dev Testing:
**Tests Added**: None. Existing tests should cover it.

**Core Scenario Tested**: SynthDet V2. Automated tests.

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
