### PR TITLE
Addressing feedback on a previous PR for disabling labeling components

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -29,6 +29,8 @@ All appearances of the term `KeyPoint` have been renamed to `Keypoint`. If you h
 
 `ScenarioBase`'s `Awake()`, `Start()`, and `Update()` functions are now private. If you previously used these, replace the usages with `OnAwake()`, `OnStart()`, and `OnUpdate()`.
 
+The interface `IGroundTruthGenerator` now contains a new method named `ClearMaterialProperties` for disabling ground truth generation on a `Labeling` component or its associated `MaterialPropertyBlock`. Update your implementing classes to including this method.
+
 ### Known Issues
 
 ### Added
@@ -51,7 +53,7 @@ The newly added `LabelManager` class now enables custom Labelers to access the l
 
 Improved UI for `KeypointTemplate` and added useful default colors for keypoint and skeleton definitions.
 
-Added the ability to switch ground-truth labeling on or off for an object at runtime by enabling or disabling its `Labeling` component.
+Added the ability to switch ground truth generation on or off for an object at runtime by enabling or disabling its `Labeling` component. A new method named `ClearMaterialProperties()` in `IGroundTruthGenerator` handles this functionality.
 
 ### Changed
 

--- a/com.unity.perception/Runtime/GroundTruth/IGroundTruthGenerator.cs
+++ b/com.unity.perception/Runtime/GroundTruth/IGroundTruthGenerator.cs
@@ -8,18 +8,18 @@ namespace UnityEngine.Perception.GroundTruth
     public interface IGroundTruthGenerator
     {
         /// <summary>
-        /// Called by <see cref="LabelManager"/> when a <see cref="Labeling"/> component is first registered, created at runtime, or enabled at runtime.
+        /// Enables ground truth generation for a <see cref="Labeling"/> component or its associated <see cref="MaterialPropertyBlock"/>. This function is called by <see cref="LabelManager"/> when a <see cref="Labeling"/> component is registered, created, or enabled.
         /// </summary>
-        /// <param name="mpb">The MaterialPropertyBlock for the given <see cref="MeshRenderer"/>. Can be used to set properties for custom rendering.</param>
+        /// <param name="mpb">The <see cref="MaterialPropertyBlock"/> for the given <see cref="MeshRenderer"/>. Can be used to set properties for custom rendering.</param>
         /// <param name="renderer">The <see cref="Renderer"/> under the given <see cref="LabelManager"/>.</param>
         /// <param name="labeling">The <see cref="LabelManager"/> component that was registered, created, or enabled</param>
         /// <param name="instanceId">The instanceId assigned to the given <see cref="LabelManager"/> instance.</param>
         void SetupMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId);
 
         /// <summary>
-        /// Called by <see cref="LabelManager"/> when a <see cref="Labeling"/> component is disabled, causing it to not be included in ground-truth generation.
+        /// Disables ground truth generation for a <see cref="Labeling"/> component or its associated <see cref="MaterialPropertyBlock"/>. This function is called by <see cref="LabelManager"/> when a <see cref="Labeling"/> component is disabled.
         /// </summary>
-        /// <param name="mpb">The MaterialPropertyBlock for the given <see cref="MeshRenderer"/>. Can be used to set properties for custom rendering.</param>
+        /// <param name="mpb">The <see cref="MaterialPropertyBlock"/> for the given <see cref="MeshRenderer"/>. Can be used to set properties for custom rendering.</param>
         /// <param name="renderer">The <see cref="Renderer"/> under the given <see cref="LabelManager"/>.</param>
         /// <param name="labeling">The <see cref="LabelManager"/> component for which ground-truth generation should stop.</param>
         /// <param name="instanceId">The instanceId assigned to the given <see cref="LabelManager"/> instance.</param>

--- a/com.unity.perception/Runtime/GroundTruth/IGroundTruthGenerator.cs
+++ b/com.unity.perception/Runtime/GroundTruth/IGroundTruthGenerator.cs
@@ -8,12 +8,21 @@ namespace UnityEngine.Perception.GroundTruth
     public interface IGroundTruthGenerator
     {
         /// <summary>
-        /// Called by <see cref="LabelManager"/> when first registered or when a Labeling is created at runtime.
+        /// Called by <see cref="LabelManager"/> when a <see cref="Labeling"/> component is first registered, created at runtime, or enabled at runtime.
         /// </summary>
-        /// <param name="mpb">The MaterialPropertyBlock for the given meshRenderer. Can be used to set properties for custom rendering.</param>
-        /// <param name="renderer">The Renderer under the given Labeling.</param>
-        /// <param name="labeling">The Labeling component created</param>
-        /// <param name="instanceId">The instanceId assigned to the given Labeling instance.</param>
+        /// <param name="mpb">The MaterialPropertyBlock for the given <see cref="MeshRenderer"/>. Can be used to set properties for custom rendering.</param>
+        /// <param name="renderer">The <see cref="Renderer"/> under the given <see cref="LabelManager"/>.</param>
+        /// <param name="labeling">The <see cref="LabelManager"/> component that was registered, created, or enabled</param>
+        /// <param name="instanceId">The instanceId assigned to the given <see cref="LabelManager"/> instance.</param>
         void SetupMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId);
+
+        /// <summary>
+        /// Called by <see cref="LabelManager"/> when a <see cref="Labeling"/> component is disabled, causing it to not be included in ground-truth generation.
+        /// </summary>
+        /// <param name="mpb">The MaterialPropertyBlock for the given <see cref="MeshRenderer"/>. Can be used to set properties for custom rendering.</param>
+        /// <param name="renderer">The <see cref="Renderer"/> under the given <see cref="LabelManager"/>.</param>
+        /// <param name="labeling">The <see cref="LabelManager"/> component for which ground-truth generation should stop.</param>
+        /// <param name="instanceId">The instanceId assigned to the given <see cref="LabelManager"/> instance.</param>
+        void ClearMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId);
     }
 }

--- a/com.unity.perception/Runtime/GroundTruth/InstanceIdToColorMapping.cs
+++ b/com.unity.perception/Runtime/GroundTruth/InstanceIdToColorMapping.cs
@@ -26,10 +26,13 @@ namespace UnityEngine.Perception.GroundTruth
         const uint k_HslCount = 64;
         const uint k_ColorsPerAlpha = 256 * 256 * 256;
         const uint k_InvalidPackedColor = 255; // packed uint for color (0, 0, 0, 255);
-        public static readonly Color32 invalidColor = new Color(0, 0, 0, 255);
         static readonly float k_GoldenRatio = (1 + Mathf.Sqrt(5)) / 2;
         const int k_HuesInEachValue = 30;
 
+        /// <summary>
+        /// The color returned when an instanceId is not mapped to any color, and for clearing ground truth material properties on a <see cref="MaterialPropertyBlock"/>.
+        /// </summary>
+        public static readonly Color32 invalidColor = new Color(0, 0, 0, 255);
         static void InitializeMaps()
         {
 

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/KeypointLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/KeypointLabeler.cs
@@ -332,97 +332,96 @@ namespace UnityEngine.Perception.GroundTruth
 
         void ProcessLabel(Labeling labeledEntity)
         {
-            if (idLabelConfig.TryGetLabelEntryFromInstanceId(labeledEntity.instanceId, out var labelEntry))
+            if (!idLabelConfig.TryGetLabelEntryFromInstanceId(labeledEntity.instanceId, out var labelEntry))
+                return;
+
+            // Cache out the data of a labeled game object the first time we see it, this will
+            // save performance each frame. Also checks to see if a labeled game object can be annotated.
+            if (!m_KnownStatus.ContainsKey(labeledEntity.instanceId))
             {
-                // Cache out the data of a labeled game object the first time we see it, this will
-                // save performance each frame. Also checks to see if a labeled game object can be annotated.
-                if (!m_KnownStatus.ContainsKey(labeledEntity.instanceId))
+                var cached = new CachedData()
                 {
-                    var cached = new CachedData()
+                    status = false,
+                    animator = null,
+                    keypoints = new KeypointEntry(),
+                    overrides = new List<(JointLabel, int)>()
+                };
+
+                var entityGameObject = labeledEntity.gameObject;
+
+                cached.keypoints.instance_id = labeledEntity.instanceId;
+                cached.keypoints.label_id = labelEntry.id;
+                cached.keypoints.template_guid = activeTemplate.templateID;
+
+                cached.keypoints.keypoints = new Keypoint[activeTemplate.keypoints.Length];
+                for (var i = 0; i < cached.keypoints.keypoints.Length; i++)
+                {
+                    cached.keypoints.keypoints[i] = new Keypoint { index = i, state = 0 };
+                }
+
+                var animator = entityGameObject.transform.GetComponentInChildren<Animator>();
+                if (animator != null)
+                {
+                    cached.animator = animator;
+                    cached.status = true;
+                }
+
+                foreach (var joint in entityGameObject.transform.GetComponentsInChildren<JointLabel>())
+                {
+                    if (TryToGetTemplateIndexForJoint(activeTemplate, joint, out var idx))
                     {
-                        status = false,
-                        animator = null,
-                        keypoints = new KeypointEntry(),
-                        overrides = new List<(JointLabel, int)>()
-                    };
-
-
-                    var entityGameObject = labeledEntity.gameObject;
-
-                    cached.keypoints.instance_id = labeledEntity.instanceId;
-                    cached.keypoints.label_id = labelEntry.id;
-                    cached.keypoints.template_guid = activeTemplate.templateID;
-
-                    cached.keypoints.keypoints = new Keypoint[activeTemplate.keypoints.Length];
-                    for (var i = 0; i < cached.keypoints.keypoints.Length; i++)
-                    {
-                        cached.keypoints.keypoints[i] = new Keypoint { index = i, state = 0 };
-                    }
-
-                    var animator = entityGameObject.transform.GetComponentInChildren<Animator>();
-                    if (animator != null)
-                    {
-                        cached.animator = animator;
+                        cached.overrides.Add((joint, idx));
                         cached.status = true;
                     }
-
-                    foreach (var joint in entityGameObject.transform.GetComponentsInChildren<JointLabel>())
-                    {
-                        if (TryToGetTemplateIndexForJoint(activeTemplate, joint, out var idx))
-                        {
-                            cached.overrides.Add((joint, idx));
-                            cached.status = true;
-                        }
-                    }
-
-                    m_KnownStatus[labeledEntity.instanceId] = cached;
                 }
 
-                var cachedData = m_KnownStatus[labeledEntity.instanceId];
+                m_KnownStatus[labeledEntity.instanceId] = cached;
+            }
 
-                if (cachedData.status)
+            var cachedData = m_KnownStatus[labeledEntity.instanceId];
+
+            if (cachedData.status)
+            {
+                var animator = cachedData.animator;
+                var keypoints = cachedData.keypoints.keypoints;
+
+                // Go through all of the rig keypoints and get their location
+                for (var i = 0; i < activeTemplate.keypoints.Length; i++)
                 {
-                    var animator = cachedData.animator;
-                    var keypoints = cachedData.keypoints.keypoints;
-
-                    // Go through all of the rig keypoints and get their location
-                    for (var i = 0; i < activeTemplate.keypoints.Length; i++)
+                    var pt = activeTemplate.keypoints[i];
+                    if (pt.associateToRig)
                     {
-                        var pt = activeTemplate.keypoints[i];
-                        if (pt.associateToRig)
+                        var bone = animator.GetBoneTransform(pt.rigLabel);
+                        if (bone != null)
                         {
-                            var bone = animator.GetBoneTransform(pt.rigLabel);
-                            if (bone != null)
-                            {
-                                var loc = ConvertToScreenSpace(bone.position);
-                                keypoints[i].index = i;
-                                keypoints[i].x = loc.x;
-                                keypoints[i].y = loc.y;
-                                keypoints[i].state = 2;
-                            }
+                            var loc = ConvertToScreenSpace(bone.position);
+                            keypoints[i].index = i;
+                            keypoints[i].x = loc.x;
+                            keypoints[i].y = loc.y;
+                            keypoints[i].state = 2;
                         }
                     }
-
-                    // Go through all of the additional or override points defined by joint labels and get
-                    // their locations
-                    foreach (var (joint, idx) in cachedData.overrides)
-                    {
-                        var loc = ConvertToScreenSpace(joint.transform.position);
-                        keypoints[idx].index = idx;
-                        keypoints[idx].x = loc.x;
-                        keypoints[idx].y = loc.y;
-                        keypoints[idx].state = 2;
-                    }
-
-                    cachedData.keypoints.pose = "unset";
-
-                    if (cachedData.animator != null)
-                    {
-                        cachedData.keypoints.pose = GetPose(cachedData.animator);
-                    }
-
-                    m_AsyncAnnotations[m_CurrentFrame].keypoints[labeledEntity.instanceId] = cachedData.keypoints;
                 }
+
+                // Go through all of the additional or override points defined by joint labels and get
+                // their locations
+                foreach (var (joint, idx) in cachedData.overrides)
+                {
+                    var loc = ConvertToScreenSpace(joint.transform.position);
+                    keypoints[idx].index = idx;
+                    keypoints[idx].x = loc.x;
+                    keypoints[idx].y = loc.y;
+                    keypoints[idx].state = 2;
+                }
+
+                cachedData.keypoints.pose = "unset";
+
+                if (cachedData.animator != null)
+                {
+                    cachedData.keypoints.pose = GetPose(cachedData.animator);
+                }
+
+                m_AsyncAnnotations[m_CurrentFrame].keypoints[labeledEntity.instanceId] = cachedData.keypoints;
             }
         }
 

--- a/com.unity.perception/Runtime/GroundTruth/Labeling/LabelEntryMatchCache.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labeling/LabelEntryMatchCache.cs
@@ -58,28 +58,32 @@ namespace UnityEngine.Perception.GroundTruth
             if (m_IdLabelConfig.TryGetMatchingConfigurationEntry(labeling, out _, out var index))
             {
                 Debug.Assert(index < k_DefaultValue, "Too many entries in the label config");
-                if (labeling.enabled)
-                {
-                    if (m_InstanceIdToLabelEntryIndexLookup.Length <= instanceId)
-                    {
-                        var oldLength = m_InstanceIdToLabelEntryIndexLookup.Length;
-                        m_InstanceIdToLabelEntryIndexLookup.Resize((int)instanceId + 1, NativeArrayOptions.ClearMemory);
 
-                        for (var i = oldLength; i < instanceId; i++)
-                            m_InstanceIdToLabelEntryIndexLookup[i] = k_DefaultValue;
-                    }
-                    m_InstanceIdToLabelEntryIndexLookup[(int)instanceId] = (ushort)index;
-                }
-                else if (m_InstanceIdToLabelEntryIndexLookup.Length > instanceId)
+                if (m_InstanceIdToLabelEntryIndexLookup.Length <= instanceId)
                 {
-                    m_InstanceIdToLabelEntryIndexLookup[(int)instanceId] = k_DefaultValue;
+                    var oldLength = m_InstanceIdToLabelEntryIndexLookup.Length;
+                    m_InstanceIdToLabelEntryIndexLookup.Resize((int)instanceId + 1, NativeArrayOptions.ClearMemory);
+
+                    for (var i = oldLength; i < instanceId; i++)
+                        m_InstanceIdToLabelEntryIndexLookup[i] = k_DefaultValue;
                 }
+                m_InstanceIdToLabelEntryIndexLookup[(int)instanceId] = (ushort)index;
             }
             else if (m_InstanceIdToLabelEntryIndexLookup.Length > instanceId)
             {
                 m_InstanceIdToLabelEntryIndexLookup[(int)instanceId] = k_DefaultValue;
             }
         }
+
+        /// <inheritdoc/>
+        void IGroundTruthGenerator.ClearMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId)
+        {
+            if (m_InstanceIdToLabelEntryIndexLookup.Length > instanceId)
+            {
+                m_InstanceIdToLabelEntryIndexLookup[(int)instanceId] = k_DefaultValue;
+            }
+        }
+
 
         /// <inheritdoc/>
         public void Dispose()

--- a/com.unity.perception/Runtime/GroundTruth/Labeling/LabelManager.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labeling/LabelManager.cs
@@ -117,7 +117,16 @@ namespace UnityEngine.Perception.GroundTruth
             {
                 terrain.GetSplatMaterialPropertyBlock(mpb);
                 foreach (var pass in m_ActiveGenerators)
-                    pass.SetupMaterialProperties(mpb, null, labeling, instanceId);
+                {
+                    if (labeling.enabled)
+                    {
+                        pass.SetupMaterialProperties(mpb, null, labeling, instanceId);
+                    }
+                    else
+                    {
+                        pass.ClearMaterialProperties(mpb, null, labeling, instanceId);
+                    }
+                }
 
                 terrain.SetSplatMaterialPropertyBlock(mpb);
             }
@@ -127,7 +136,16 @@ namespace UnityEngine.Perception.GroundTruth
             {
                 renderer.GetPropertyBlock(mpb);
                 foreach (var pass in m_ActiveGenerators)
-                    pass.SetupMaterialProperties(mpb, renderer, labeling, instanceId);
+                {
+                    if (labeling.enabled)
+                    {
+                        pass.SetupMaterialProperties(mpb, renderer, labeling, instanceId);
+                    }
+                    else
+                    {
+                        pass.ClearMaterialProperties(mpb, renderer, labeling, instanceId);
+                    }
+                }
 
                 renderer.SetPropertyBlock(mpb);
 
@@ -139,7 +157,16 @@ namespace UnityEngine.Perception.GroundTruth
                     if (!mpb.isEmpty)
                     {
                         foreach (var pass in m_ActiveGenerators)
-                            pass.SetupMaterialProperties(mpb, renderer, labeling, instanceId);
+                        {
+                            if (labeling.enabled)
+                            {
+                                pass.SetupMaterialProperties(mpb, renderer, labeling, instanceId);
+                            }
+                            else
+                            {
+                                pass.ClearMaterialProperties(mpb, renderer, labeling, instanceId);
+                            }
+                        }
 
                         renderer.SetPropertyBlock(mpb, i);
                     }

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/GroundTruthCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/GroundTruthCrossPipelinePass.cs
@@ -116,5 +116,8 @@ namespace UnityEngine.Perception.GroundTruth
 
         public abstract void SetupMaterialProperties(
             MaterialPropertyBlock mpb, Renderer meshRenderer, Labeling labeling, uint instanceId);
+
+        public abstract void ClearMaterialProperties(
+            MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId);
     }
 }

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/InstanceSegmentationCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/InstanceSegmentationCrossPipelinePass.cs
@@ -69,13 +69,15 @@ namespace UnityEngine.Perception.GroundTruth
             if (!found)
                 Debug.LogError($"Could not get a unique color for {instanceId}");
 
-            if (labeling.enabled)
-                mpb.SetVector(k_SegmentationIdProperty, (Color)color);
-            else
-                mpb.SetVector(k_SegmentationIdProperty, (Color) InstanceIdToColorMapping.invalidColor);
+            mpb.SetVector(k_SegmentationIdProperty, (Color)color);
 #if PERCEPTION_DEBUG
             Debug.Log($"Assigning id. Frame {Time.frameCount} id {id}");
 #endif
+        }
+
+        public override void ClearMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId)
+        {
+            mpb.SetVector(k_SegmentationIdProperty, (Color) InstanceIdToColorMapping.invalidColor);
         }
     }
 }

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/LensDistortionCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/LensDistortionCrossPipelinePass.cs
@@ -185,6 +185,11 @@ namespace UnityEngine.Perception.GroundTruth
         {
             SetLensDistortionShaderParameters();
         }
+
+        public override void ClearMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId)
+        {
+            SetLensDistortionShaderParameters();
+        }
     }
 }
 

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/SemanticSegmentationCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/SemanticSegmentationCrossPipelinePass.cs
@@ -65,25 +65,24 @@ namespace UnityEngine.Perception.GroundTruth
         {
             var entry = new SemanticSegmentationLabelEntry();
             var found = false;
-            if (labeling.enabled)
+
+            foreach (var l in m_LabelConfig.labelEntries)
             {
-                foreach (var l in m_LabelConfig.labelEntries)
+                if (labeling.labels.Contains(l.label))
                 {
-                    if (labeling.labels.Contains(l.label))
-                    {
-                        entry = l;
-                        found = true;
-                        break;
-                    }
+                    entry = l;
+                    found = true;
+                    break;
                 }
             }
 
             // Set the labeling ID so that it can be accessed in ClassSemanticSegmentationPass.shader
-            if (found)
-                mpb.SetVector(k_LabelingId, entry.color);
-            else
-                mpb.SetVector(k_LabelingId, Color.black);
+            mpb.SetVector(k_LabelingId, found ? entry.color : Color.black);
+        }
 
+        public override void ClearMaterialProperties(MaterialPropertyBlock mpb, Renderer renderer, Labeling labeling, uint instanceId)
+        {
+            mpb.SetVector(k_LabelingId, Color.black);
         }
     }
 }

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/HdrpPasses/GroundTruthPass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/HdrpPasses/GroundTruthPass.cs
@@ -13,6 +13,9 @@ namespace UnityEngine.Perception.GroundTruth
         public abstract void SetupMaterialProperties(
             MaterialPropertyBlock mpb, Renderer meshRenderer, Labeling labeling, uint instanceId);
 
+        public abstract void ClearMaterialProperties(
+            MaterialPropertyBlock mpb, Renderer meshRenderer, Labeling labeling, uint instanceId);
+
         protected GroundTruthPass(Camera targetCamera)
         {
             this.targetCamera = targetCamera;

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/KeypointGroundTruthTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/KeypointGroundTruthTests.cs
@@ -291,7 +291,7 @@ namespace GroundTruthTests
             texture.Create();
             var cam = SetupCamera(SetUpLabelConfig(), template, (frame, data) =>
             {
-                incoming.Add(data);
+                incoming.Add(new List<KeypointLabeler.KeypointEntry>(data));
             }, texture);
 
             var cube = TestHelper.CreateLabeledCube(scale: 6, z: 8);
@@ -336,6 +336,73 @@ namespace GroundTruthTests
         }
 
         [UnityTest]
+        public IEnumerator Keypoint_TestStaticLabeledCube_WithDisabledLabeling_AndSwitchingLabelingState()
+        {
+            var incoming = new List<List<KeypointLabeler.KeypointEntry>>();
+            var template = CreateTestTemplate(Guid.NewGuid(), "TestTemplate");
+            var texture = new RenderTexture(1024, 768, 16);
+            texture.Create();
+            var cam = SetupCamera(SetUpLabelConfig(), template, (frame, data) =>
+            {
+                incoming.Add(new List<KeypointLabeler.KeypointEntry>(data));
+            }, texture);
+
+            var cube = TestHelper.CreateLabeledCube(scale: 6, z: 8);
+            SetupCubeJoints(cube, template);
+            var labeling = cube.GetComponent<Labeling>();
+
+            cube.SetActive(true);
+            cam.SetActive(true);
+
+            AddTestObjectForCleanup(cam);
+            AddTestObjectForCleanup(cube);
+
+            labeling.enabled = false;
+            yield return null;
+
+            labeling.enabled = true;
+            yield return null;
+
+            labeling.enabled = false;
+            yield return null;
+
+            //force all async readbacks to complete
+            DestroyTestObject(cam);
+            texture.Release();
+
+            var testCase = incoming[0];
+            Assert.AreEqual(0, testCase.Count);
+
+            testCase = incoming[1];
+            Assert.AreEqual(1, testCase.Count);
+            var t = testCase.First();
+            Assert.NotNull(t);
+            Assert.AreEqual(1, t.instance_id);
+            Assert.AreEqual(1, t.label_id);
+            Assert.AreEqual(template.templateID.ToString(), t.template_guid);
+            Assert.AreEqual(9, t.keypoints.Length);
+
+            Assert.AreEqual(t.keypoints[0].x, t.keypoints[1].x);
+            Assert.AreEqual(t.keypoints[2].x, t.keypoints[3].x);
+            Assert.AreEqual(t.keypoints[4].x, t.keypoints[5].x);
+            Assert.AreEqual(t.keypoints[6].x, t.keypoints[7].x);
+
+            Assert.AreEqual(t.keypoints[0].y, t.keypoints[3].y);
+            Assert.AreEqual(t.keypoints[1].y, t.keypoints[2].y);
+            Assert.AreEqual(t.keypoints[4].y, t.keypoints[7].y);
+            Assert.AreEqual(t.keypoints[5].y, t.keypoints[6].y);
+
+            for (var i = 0; i < 9; i++) Assert.AreEqual(i, t.keypoints[i].index);
+            for (var i = 0; i < 8; i++) Assert.AreEqual(2, t.keypoints[i].state);
+            Assert.Zero(t.keypoints[8].state);
+            Assert.Zero(t.keypoints[8].x);
+            Assert.Zero(t.keypoints[8].y);
+
+            testCase = incoming[2];
+            Assert.AreEqual(0, testCase.Count);
+        }
+
+        [UnityTest]
         public IEnumerator Keypoint_TestAllOffScreen()
         {
             var incoming = new List<List<KeypointLabeler.KeypointEntry>>();
@@ -343,7 +410,7 @@ namespace GroundTruthTests
 
             var cam = SetupCamera(SetUpLabelConfig(), template, (frame, data) =>
             {
-                incoming.Add(data);
+                incoming.Add(new List<KeypointLabeler.KeypointEntry>(data));
             });
 
             var cube = TestHelper.CreateLabeledCube(scale: 6, z: 8);
@@ -376,7 +443,7 @@ namespace GroundTruthTests
             texture.Create();
             var cam = SetupCamera(SetUpLabelConfig(), template, (frame, data) =>
             {
-                incoming.Add(data);
+                incoming.Add(new List<KeypointLabeler.KeypointEntry>(data));
             }, texture);
 
             var cube = TestHelper.CreateLabeledCube(scale: 6, z: 8);
@@ -430,7 +497,7 @@ namespace GroundTruthTests
             texture.Create();
             var cam = SetupCamera(SetUpLabelConfig(), template, (frame, data) =>
             {
-                incoming.Add(data);
+                incoming.Add(new List<KeypointLabeler.KeypointEntry>(data));
             }, texture);
 
             var cube = TestHelper.CreateLabeledCube(scale: 6, z: 8);
@@ -486,7 +553,7 @@ namespace GroundTruthTests
             texture.Create();
             var cam = SetupCamera(SetUpLabelConfig(), template, (frame, data) =>
             {
-                incoming.Add(data);
+                incoming.Add(new List<KeypointLabeler.KeypointEntry>(data));
             }, texture);
 
             var cube = TestHelper.CreateLabeledCube(scale: 6, z: 8);
@@ -536,7 +603,7 @@ namespace GroundTruthTests
             var texture = new RenderTexture(1024, 768, 16);
             var cam = SetupCamera(SetUpLabelConfig(), template, (frame, data) =>
             {
-                incoming.Add(data);
+                incoming.Add(new List<KeypointLabeler.KeypointEntry>(data));
             }, texture);
 
             var cube = TestHelper.CreateLabeledCube(scale: 6, z: 8);
@@ -595,7 +662,7 @@ namespace GroundTruthTests
             texture.Create();
             var cam = SetupCamera(SetUpLabelConfig(), template, (frame, data) =>
             {
-                incoming.Add(data);
+                incoming.Add(new List<KeypointLabeler.KeypointEntry>(data));
             }, texture);
 
             var cameraComponent = cam.GetComponent<Camera>();


### PR DESCRIPTION
# Peer Review Information:
Information on any code, feature, documentation changes here

- Added the ClearMaterialProperties method to IGroundTruthGenerator 
- Fixed an issue in keypoint groundtruth tests where passing a list of keypoints by reference could cause issues with data being overwrriten if more than one frame was tested.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.4

## Dev Testing:
**Tests Added**: 

- Added test for keypoint ground truth generation with a disabled labeling component (plus switching at runtime)

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [x] - Updated changelog
