### PR TITLE
Amending dataset schema to describe correct coordinate system

### DIFF
--- a/com.unity.perception/Documentation~/Schema/Synthetic_Dataset_Schema.md
+++ b/com.unity.perception/Documentation~/Schema/Synthetic_Dataset_Schema.md
@@ -216,7 +216,7 @@ bounding_box_3d {
   label_id:      <int>   -- Integer identifier of the label
   label_name:    <str>   -- String identifier of the label
   instance_id:   <str>   -- UUID of the instance.
-  translation {          -- 3d bounding box's center location in meters with respect to global coordinate system.
+  translation {          -- 3d bounding box's center location in meters with respect to the sensor's coordinate system
     x:           <float> -- The x coordinate
     y:           <float> -- The y coordinate
     z:           <float> -- The z coordinate


### PR DESCRIPTION
The summary for the 3d bounding box states the coordinates are from the sensor's reference frame, but the string for the translational component says it's global.  I *think* this is just a typo in the doc, so correcting the description to match the summary for this type of entry.