### PR TITLE
A fix that prevents normal sampler returning values outside of min max

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+A bug in the Normal Sampler where it would return values less than the passed in min, or greater than the passed in max, for random values very close to 0 or 1 respectively.
+
 ## [0.8.0-preview.2] - 2021-03-15
 
 ### Upgrade Notes

--- a/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
+++ b/com.unity.perception/Runtime/Randomization/Samplers/SamplerUtility.cs
@@ -177,7 +177,7 @@ namespace UnityEngine.Perception.Randomization.Samplers
                 return min;
 
             var stdTruncNorm = NormalCdfInverse(c);
-            return stdTruncNorm * stdDev + mean;
+            return math.clamp(stdTruncNorm * stdDev + mean, min, max);
         }
 
         /// <summary>


### PR DESCRIPTION
# Peer Review Information:
Fixed a bug where random values really close to either 0 or 1 (around 7 decimal digits) the normal randomizer could return values outside of the min/max values.

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2019.3

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [x] - Updated docs
- [x] - Updated changelog
