### PR TITLE
Fix HDRP warnings on 2020.X

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+Fixed compiler warnings in projects with HDRP on 2020.1 and later
+
 ## [0.8.0-preview.2] - 2021-03-15
 
 ### Upgrade Notes

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/HdrpPasses/GroundTruthPass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/HdrpPasses/GroundTruthPass.cs
@@ -30,9 +30,18 @@ namespace UnityEngine.Perception.GroundTruth
             targetDepthBuffer = TargetBuffer.Custom;
         }
 
-        protected sealed override void Execute(
-            ScriptableRenderContext renderContext, CommandBuffer cmd, HDCamera hdCamera, CullingResults cullingResult)
+        //overrides obsolete member in HDRP on 2020.1+. Re-address when removing 2019.4 support or the API is dropped
+#if HDRP_9_OR_NEWER
+        protected override void Execute(CustomPassContext ctx)
         {
+            ScriptableRenderContext renderContext = ctx.renderContext;
+            var cmd = ctx.cmd;
+            var hdCamera = ctx.hdCamera;
+            var cullingResult = ctx.cullingResults;
+#else
+        protected override void Execute(ScriptableRenderContext renderContext, CommandBuffer cmd, HDCamera hdCamera, CullingResults cullingResult)
+        {
+#endif
             // CustomPasses are executed for each camera. We only want to run for the target camera
             if (hdCamera.camera != targetCamera)
                 return;

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/HdrpPasses/InstanceSegmentationPass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/HdrpPasses/InstanceSegmentationPass.cs
@@ -20,8 +20,18 @@ namespace UnityEngine.Perception.GroundTruth
         [UsedImplicitly]
         public InstanceSegmentationPass() {}
 
+        //overrides obsolete member in HDRP on 2020.1+. Re-address when removing 2019.4 support or the API is dropped
+#if HDRP_9_OR_NEWER
+        protected override void Execute(CustomPassContext ctx)
+        {
+            ScriptableRenderContext renderContext = ctx.renderContext;
+            var cmd = ctx.cmd;
+            var hdCamera = ctx.hdCamera;
+            var cullingResult = ctx.cullingResults;
+#else
         protected override void Execute(ScriptableRenderContext renderContext, CommandBuffer cmd, HDCamera hdCamera, CullingResults cullingResult)
         {
+#endif
             CoreUtils.SetRenderTarget(cmd, targetTexture, ClearFlag.All);
             m_InstanceSegmentationCrossPipelinePass.Execute(renderContext, cmd, hdCamera.camera, cullingResult);
         }

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/HdrpPasses/LensDistortionPass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/HdrpPasses/LensDistortionPass.cs
@@ -38,8 +38,18 @@ namespace UnityEngine.Perception.GroundTruth
             lensDistortionCrossPipelinePass.Setup();
         }
 
+        //overrides obsolete member in HDRP on 2020.1+. Re-address when removing 2019.4 support or the API is dropped
+#if HDRP_9_OR_NEWER
+        protected override void Execute(CustomPassContext ctx)
+        {
+            ScriptableRenderContext renderContext = ctx.renderContext;
+            var cmd = ctx.cmd;
+            var hdCamera = ctx.hdCamera;
+            var cullingResult = ctx.cullingResults;
+#else
         protected override void Execute(ScriptableRenderContext renderContext, CommandBuffer cmd, HDCamera hdCamera, CullingResults cullingResult)
         {
+#endif
             CoreUtils.SetRenderTarget(cmd, targetTexture);
             lensDistortionCrossPipelinePass.Execute(renderContext, cmd, hdCamera.camera, cullingResult);
         }

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/HdrpPasses/SemanticSegmentationPass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/HdrpPasses/SemanticSegmentationPass.cs
@@ -40,8 +40,18 @@ namespace UnityEngine.Perception.GroundTruth
             m_SemanticSegmentationCrossPipelinePass.Setup();
         }
 
+        //overrides obsolete member in HDRP on 2020.1+. Re-address when removing 2019.4 support or the API is dropped
+#if HDRP_9_OR_NEWER
+        protected override void Execute(CustomPassContext ctx)
+        {
+            ScriptableRenderContext renderContext = ctx.renderContext;
+            var cmd = ctx.cmd;
+            var hdCamera = ctx.hdCamera;
+            var cullingResult = ctx.cullingResults;
+#else
         protected override void Execute(ScriptableRenderContext renderContext, CommandBuffer cmd, HDCamera hdCamera, CullingResults cullingResult)
         {
+#endif
             CoreUtils.SetRenderTarget(cmd, targetTexture);
             m_SemanticSegmentationCrossPipelinePass.Execute(renderContext, cmd, hdCamera.camera, cullingResult);
         }

--- a/com.unity.perception/Runtime/Unity.Perception.Runtime.asmdef
+++ b/com.unity.perception/Runtime/Unity.Perception.Runtime.asmdef
@@ -1,6 +1,5 @@
 {
     "name": "Unity.Perception.Runtime",
-    "rootNamespace": "",
     "references": [
         "Unity.Burst",
         "Unity.Collections",
@@ -40,7 +39,7 @@
         },
         {
             "name": "com.unity.render-pipelines.high-definition",
-            "expression": "9",
+            "expression": "9.0",
             "define": "HDRP_9_OR_NEWER"
         }
     ],

--- a/com.unity.perception/Runtime/Unity.Perception.Runtime.asmdef
+++ b/com.unity.perception/Runtime/Unity.Perception.Runtime.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Unity.Perception.Runtime",
+    "rootNamespace": "",
     "references": [
         "Unity.Burst",
         "Unity.Collections",
@@ -36,6 +37,11 @@
             "name": "com.unity.simulation.capture",
             "expression": "0.0.10-preview.16",
             "define": "SIMULATION_CAPTURE_0_0_10_PREVIEW_16_OR_NEWER"
+        },
+        {
+            "name": "com.unity.render-pipelines.high-definition",
+            "expression": "9",
+            "define": "HDRP_9_OR_NEWER"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
# Peer Review Information:
Fix a few HDRP warnings on 2020.1/2

## Editor / Package versioning:
**Editor Version Target (i.e. 19.3, 20.1)**: 2020.1/2020.2

## Dev Testing:
**Tests Added**: None

**Core Scenario Tested**: Tested on 2020.1 and 2020.2

**At Risk Areas**: 

**Notes + Expectations**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
