### PR TITLE
RandomizerTag.OnEnable is now virtual

### DIFF
--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerTag.cs
@@ -15,7 +15,7 @@ namespace UnityEngine.Perception.Randomization.Randomizers
         /// OnEnable is called when this RandomizerTag is enabled, either created, instantiated, or enabled via
         /// the Unity Editor
         /// </summary>
-        protected void OnEnable()
+        protected virtual void OnEnable()
         {
             Register();
         }


### PR DESCRIPTION
# Peer Review Information:
Just released I forgot to make RandomizerTag.OnEnable virtual (though I did make RandomizerTag.OnDisable virtual...).

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [ ] - Updated changelog
