### PR TITLE
Fix warnings caused by animation randomizer

### DIFF
--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/AnimationRandomizer.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Randomizers/AnimationRandomizer.cs
@@ -20,6 +20,9 @@ namespace UnityEngine.Perception.Randomization.Randomizers.SampleRandomizers
 
         void RandomizeAnimation(AnimationRandomizerTag tag)
         {
+            if (!tag.gameObject.activeInHierarchy)
+                return;
+
             var animator = tag.gameObject.GetComponent<Animator>();
             animator.applyRootMotion = tag.applyRootMotion;
 


### PR DESCRIPTION
# Peer Review Information:
AnimationRandomizer was causing warnings each frame when randomizing disabled GameObjects. This change fixes that warning by not randomizing disabled GameObjects.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Added**: None

**Core Scenario Tested**: Tested using random person placement scene on 2020.1

**At Risk Areas**: Animation randomization. Low risk fix

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
- [ ] - Updated test rail
