### PR TITLE
Adding sky color control to semantic segmentation

### DIFF
--- a/TestProjects/PerceptionHDRP/Assets/SemanticSegmentationLabelingConfiguration.asset
+++ b/TestProjects/PerceptionHDRP/Assets/SemanticSegmentationLabelingConfiguration.asset
@@ -21,3 +21,4 @@ MonoBehaviour:
     color: {r: 0, g: 1, b: 0.16973758, a: 1}
   - label: Terrain
     color: {r: 0.8207547, g: 0, b: 0.6646676, a: 1}
+  skyColor: {r: 0, g: 0, b: 0, a: 1}

--- a/TestProjects/PerceptionHDRP/Packages/packages-lock.json
+++ b/TestProjects/PerceptionHDRP/Packages/packages-lock.json
@@ -81,7 +81,7 @@
         "com.unity.collections": "0.9.0-preview.6",
         "com.unity.nuget.newtonsoft-json": "1.1.2",
         "com.unity.render-pipelines.core": "7.1.6",
-        "com.unity.simulation.capture": "0.0.10-preview.19",
+        "com.unity.simulation.capture": "0.0.10-preview.20",
         "com.unity.simulation.client": "0.0.10-preview.10",
         "com.unity.simulation.core": "0.0.10-preview.22"
       }
@@ -126,7 +126,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.simulation.capture": {
-      "version": "0.0.10-preview.19",
+      "version": "0.0.10-preview.20",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/TestProjects/PerceptionURP/Assets/SemanticSegmentationLabelingConfiguration.asset
+++ b/TestProjects/PerceptionURP/Assets/SemanticSegmentationLabelingConfiguration.asset
@@ -21,3 +21,4 @@ MonoBehaviour:
     color: {r: 0, g: 1, b: 0.16973758, a: 1}
   - label: Terrain
     color: {r: 0.8207547, g: 0, b: 0.6646676, a: 1}
+  skyColor: {r: 0, g: 0, b: 0, a: 1}

--- a/TestProjects/PerceptionURP/Packages/packages-lock.json
+++ b/TestProjects/PerceptionURP/Packages/packages-lock.json
@@ -81,7 +81,7 @@
         "com.unity.collections": "0.9.0-preview.6",
         "com.unity.nuget.newtonsoft-json": "1.1.2",
         "com.unity.render-pipelines.core": "7.1.6",
-        "com.unity.simulation.capture": "0.0.10-preview.19",
+        "com.unity.simulation.capture": "0.0.10-preview.20",
         "com.unity.simulation.client": "0.0.10-preview.10",
         "com.unity.simulation.core": "0.0.10-preview.22"
       }
@@ -115,7 +115,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.simulation.capture": {
-      "version": "0.0.10-preview.19",
+      "version": "0.0.10-preview.20",
       "depth": 1,
       "source": "registry",
       "dependencies": {

--- a/com.unity.perception/Editor/GroundTruth/IdLabelConfigEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/IdLabelConfigEditor.cs
@@ -37,6 +37,8 @@ namespace UnityEditor.Perception.GroundTruth
 
             m_StartingIdEnumField.SetEnabled(AutoAssign);
 
+            m_IdSpecificUi.style.display = DisplayStyle.None;
+
             AutoAssignIdsIfNeeded();
             m_MoveDownButton.clicked += MoveSelectedItemDown;
             m_MoveUpButton.clicked += MoveSelectedItemUp;

--- a/com.unity.perception/Editor/GroundTruth/IdLabelConfigEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/IdLabelConfigEditor.cs
@@ -37,7 +37,7 @@ namespace UnityEditor.Perception.GroundTruth
 
             m_StartingIdEnumField.SetEnabled(AutoAssign);
 
-            m_IdSpecificUi.style.display = DisplayStyle.None;
+            m_SkyColorUi.style.display = DisplayStyle.None;
 
             AutoAssignIdsIfNeeded();
             m_MoveDownButton.clicked += MoveSelectedItemDown;

--- a/com.unity.perception/Editor/GroundTruth/LabelConfigEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/LabelConfigEditor.cs
@@ -41,9 +41,12 @@ namespace UnityEditor.Perception.GroundTruth
         protected Button m_MoveDownButton;
         protected VisualElement m_MoveButtons;
         protected VisualElement m_IdSpecificUi;
-        protected VisualElement m_BackgroundColorUi;
+        protected VisualElement m_SkyColorUi;
         protected EnumField m_StartingIdEnumField;
         protected Toggle m_AutoIdToggle;
+
+        protected ColorField m_SkyColorField;
+        protected Label m_SkyHexLabel;
 
 
         public void OnEnable()
@@ -115,7 +118,9 @@ namespace UnityEditor.Perception.GroundTruth
             m_StartingIdEnumField = m_Root.Q<EnumField>("starting-id-dropdown");
             m_AutoIdToggle = m_Root.Q<Toggle>("auto-id-toggle");
             m_IdSpecificUi = m_Root.Q<VisualElement>("id-specific-ui");
-            m_BackgroundColorUi = m_Root.Q<VisualElement>("background-color-ui");
+            m_SkyColorUi = m_Root.Q<VisualElement>("sky-color-ui");
+            m_SkyColorField = m_Root.Q<ColorField>("sky-color-value");
+            m_SkyHexLabel = m_Root.Q<Label>("sky-color-hex");
 
             m_SaveButton.SetEnabled(false);
 

--- a/com.unity.perception/Editor/GroundTruth/LabelConfigEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/LabelConfigEditor.cs
@@ -41,6 +41,7 @@ namespace UnityEditor.Perception.GroundTruth
         protected Button m_MoveDownButton;
         protected VisualElement m_MoveButtons;
         protected VisualElement m_IdSpecificUi;
+        protected VisualElement m_BackgroundColorUi;
         protected EnumField m_StartingIdEnumField;
         protected Toggle m_AutoIdToggle;
 
@@ -114,6 +115,7 @@ namespace UnityEditor.Perception.GroundTruth
             m_StartingIdEnumField = m_Root.Q<EnumField>("starting-id-dropdown");
             m_AutoIdToggle = m_Root.Q<Toggle>("auto-id-toggle");
             m_IdSpecificUi = m_Root.Q<VisualElement>("id-specific-ui");
+            m_BackgroundColorUi = m_Root.Q<VisualElement>("background-color-ui");
 
             m_SaveButton.SetEnabled(false);
 

--- a/com.unity.perception/Editor/GroundTruth/SemanticSegmentationLabelConfigEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/SemanticSegmentationLabelConfigEditor.cs
@@ -16,7 +16,7 @@ namespace UnityEditor.Perception.GroundTruth
             m_MoveButtons.style.display = DisplayStyle.None;
             m_IdSpecificUi.style.display = DisplayStyle.None;
 
-            var skyColorProperty = serializedObject.FindProperty(nameof(SemanticSegmentationLabelConfig.backgroundColor));
+            var skyColorProperty = serializedObject.FindProperty(nameof(SemanticSegmentationLabelConfig.skyColor));
             m_SkyColorField.BindProperty(skyColorProperty);
             m_SkyColorField.RegisterValueChangedCallback(e => UpdateSkyHexLabel(e.newValue));
             UpdateSkyHexLabel(skyColorProperty.colorValue);

--- a/com.unity.perception/Editor/GroundTruth/SemanticSegmentationLabelConfigEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/SemanticSegmentationLabelConfigEditor.cs
@@ -15,6 +15,16 @@ namespace UnityEditor.Perception.GroundTruth
         {
             m_MoveButtons.style.display = DisplayStyle.None;
             m_IdSpecificUi.style.display = DisplayStyle.None;
+
+            var skyColorProperty = serializedObject.FindProperty(nameof(SemanticSegmentationLabelConfig.backgroundColor));
+            m_SkyColorField.BindProperty(skyColorProperty);
+            m_SkyColorField.RegisterValueChangedCallback(e => UpdateSkyHexLabel(e.newValue));
+            UpdateSkyHexLabel(skyColorProperty.colorValue);
+        }
+
+        private void UpdateSkyHexLabel(Color colorValue)
+        {
+            m_SkyHexLabel.text = "#" + ColorUtility.ToHtmlStringRGBA(colorValue);
         }
 
         public override void PostRemoveOperations()

--- a/com.unity.perception/Editor/GroundTruth/Uss/Styles.uss
+++ b/com.unity.perception/Editor/GroundTruth/Uss/Styles.uss
@@ -16,12 +16,6 @@
     align-content: center;
 }
 
-.background-color {
-    margin: 3px 4px 3px 4px;
-    flex-direction: row;
-    align-content: center;
-}
-
 .labeling__added-label-value {
     width: 40%;
     flex-grow: 1;

--- a/com.unity.perception/Editor/GroundTruth/Uss/Styles.uss
+++ b/com.unity.perception/Editor/GroundTruth/Uss/Styles.uss
@@ -16,6 +16,12 @@
     align-content: center;
 }
 
+.background-color {
+    margin: 3px 4px 3px 4px;
+    flex-direction: row;
+    align-content: center;
+}
+
 .labeling__added-label-value {
     width: 40%;
     flex-grow: 1;

--- a/com.unity.perception/Editor/GroundTruth/Uxml/ColoredLabelElementInLabelConfig.uxml
+++ b/com.unity.perception/Editor/GroundTruth/Uxml/ColoredLabelElementInLabelConfig.uxml
@@ -1,12 +1,12 @@
 <UXML xmlns="UnityEngine.UIElements" xmlns:editor="UnityEditor.UIElements">
     <VisualElement class="added-label" style="padding-top: 3px;">
         <Button name="remove-button" class="labeling__remove-item-button"/>
+        <TextField name="label-value" class="labeling__added-label-value"/>
         <VisualElement class="generic-hover"
                        style="min-width : 137px; flex-direction: row; padding: 3px 0 3px 6px; margin-left: 3px; margin-right: 3px; border-width: 1px; border-color: #555555; border-radius: 4px;">
             <editor:ColorField name="label-color-value" style="min-width : 60px; max-width: 60px; align-self:center; margin:2px"/>
             <Label name="label-color-hex" style="font-size: 11; min-width : 60px; max-width: 60px; align-self:center;"/>
         </VisualElement>
-        <TextField name="label-value" class="labeling__added-label-value"/>
         <VisualElement style="min-width:20px; flex-direction: row; display:none">
             <Button name="move-up-button" class="move-label-in-config-button move-up" style="margin-right:-2px"/>
             <Button name="move-down-button" class="move-label-in-config-button move-down"/>

--- a/com.unity.perception/Editor/GroundTruth/Uxml/LabelConfig_Main.uxml
+++ b/com.unity.perception/Editor/GroundTruth/Uxml/LabelConfig_Main.uxml
@@ -2,6 +2,7 @@
     <VisualElement class="outer-container" name="outer-container">
         <Style src="../Uss/Styles.uss"/>
         <VisualElement class="inner-container" name="id-specific-ui">
+            <Label text="Options" name="options-title" class="title-label"/>
             <Toggle name="auto-id-toggle" text="Auto Assign IDs" style="margin:0" binding-path="autoAssignIds"/>
             <VisualElement style="flex-direction: row; flex-grow: 1;">
                 <editor:EnumField label="Starting ID" name="starting-id-dropdown" binding-path="startingLabelId"
@@ -9,11 +10,16 @@
             </VisualElement>
         </VisualElement>
         <VisualElement class="inner-container" name="sky-color-ui">
-            <VisualElement class="generic-hover"
-                           style="min-width : 137px; flex-direction: row; padding: 3px 0 3px 6px; margin-left: 3px; margin-right: 3px;">
-                <Label text="Sky Color" name="added-labels-title"  style="font-size: 11; min-width : 60px; max-width: 60px; align-self:center;"/>
-                <editor:ColorField name="sky-color-value" style="min-width : 60px; max-width: 60px; align-self:center; margin:2px"/>
-                <Label name="sky-color-hex" style="font-size: 11; min-width : 60px; max-width: 60px; align-self:center;"/>
+            <Label text="Options" name="options-title" class="title-label"/>
+            <VisualElement style="flex-direction: row; flex-grow: 1;">
+                <Label text="Sky Color" name="added-labels-title"
+                       style="flex-grow: 1; font-size: 11; min-width : 60px; align-self:center;"/>
+                <VisualElement class="generic-hover"
+                               style="min-width : 137px; flex-direction: row; padding: 3px 5px 3px 5px; margin-left: 3px; margin-right: 3px; border-width: 1px; border-color: #666666; border-radius: 4px;">
+                    <editor:ColorField name="sky-color-value" style="min-width : 60px; max-width: 60px; align-self:center;"/>
+                    <Label name="sky-color-hex"
+                           style="font-size: 11; min-width : 60px; max-width: 60px; align-self:center; margin: 2px"/>
+                </VisualElement>
             </VisualElement>
         </VisualElement>
         <VisualElement name="added-labels" class="inner-container" style="margin-top:5px">

--- a/com.unity.perception/Editor/GroundTruth/Uxml/LabelConfig_Main.uxml
+++ b/com.unity.perception/Editor/GroundTruth/Uxml/LabelConfig_Main.uxml
@@ -8,6 +8,14 @@
                                   style="flex-grow:1; margin:0"/>
             </VisualElement>
         </VisualElement>
+        <VisualElement class="inner-container" name="background-color-ui">
+            <Label text="Background Color" name="added-labels-title" class="title-label"/>
+            <VisualElement class="generic-hover"
+                           style="min-width : 137px; flex-direction: row; padding: 3px 0 3px 6px; margin-left: 3px; margin-right: 3px; border-width: 1px; border-color: #555555; border-radius: 4px;">
+                <editor:ColorField name="label-color-value" style="min-width : 60px; max-width: 60px; align-self:center; margin:2px"/>
+                <Label name="label-color-hex" style="font-size: 11; min-width : 60px; max-width: 60px; align-self:center;"/>
+            </VisualElement>
+        </VisualElement>
         <VisualElement name="added-labels" class="inner-container" style="margin-top:5px">
             <Label text="Added Labels" name="added-labels-title" class="title-label"/>
             <ListView name="labels-listview" class="labeling__label-listview" style="margin-top: 5px;"/>

--- a/com.unity.perception/Editor/GroundTruth/Uxml/LabelConfig_Main.uxml
+++ b/com.unity.perception/Editor/GroundTruth/Uxml/LabelConfig_Main.uxml
@@ -8,12 +8,12 @@
                                   style="flex-grow:1; margin:0"/>
             </VisualElement>
         </VisualElement>
-        <VisualElement class="inner-container" name="background-color-ui">
-            <Label text="Background Color" name="added-labels-title" class="title-label"/>
+        <VisualElement class="inner-container" name="sky-color-ui">
             <VisualElement class="generic-hover"
-                           style="min-width : 137px; flex-direction: row; padding: 3px 0 3px 6px; margin-left: 3px; margin-right: 3px; border-width: 1px; border-color: #555555; border-radius: 4px;">
-                <editor:ColorField name="label-color-value" style="min-width : 60px; max-width: 60px; align-self:center; margin:2px"/>
-                <Label name="label-color-hex" style="font-size: 11; min-width : 60px; max-width: 60px; align-self:center;"/>
+                           style="min-width : 137px; flex-direction: row; padding: 3px 0 3px 6px; margin-left: 3px; margin-right: 3px;">
+                <Label text="Sky Color" name="added-labels-title"  style="font-size: 11; min-width : 60px; max-width: 60px; align-self:center;"/>
+                <editor:ColorField name="sky-color-value" style="min-width : 60px; max-width: 60px; align-self:center; margin:2px"/>
+                <Label name="sky-color-hex" style="font-size: 11; min-width : 60px; max-width: 60px; align-self:center;"/>
             </VisualElement>
         </VisualElement>
         <VisualElement name="added-labels" class="inner-container" style="margin-top:5px">

--- a/com.unity.perception/Runtime/GroundTruth/Labeling/SemanticSegmentationLabelConfig.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labeling/SemanticSegmentationLabelConfig.cs
@@ -23,9 +23,9 @@ namespace UnityEngine.Perception.GroundTruth {
 
 
         /// <summary>
-        /// The color to use for the background of semantic segmentation images
+        /// The color to use for the sky in semantic segmentation images
         /// </summary>
-        public Color backgroundColor = Color.black;
+        public Color skyColor = Color.black;
     }
 
     /// <summary>

--- a/com.unity.perception/Runtime/GroundTruth/Labeling/SemanticSegmentationLabelConfig.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labeling/SemanticSegmentationLabelConfig.cs
@@ -25,7 +25,7 @@ namespace UnityEngine.Perception.GroundTruth {
         /// <summary>
         /// The color to use for the background of semantic segmentation images
         /// </summary>
-        public Color backgroundColor { get; set; } = Color.black;
+        public Color backgroundColor = Color.black;
     }
 
     /// <summary>

--- a/com.unity.perception/Runtime/GroundTruth/Labeling/SemanticSegmentationLabelConfig.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labeling/SemanticSegmentationLabelConfig.cs
@@ -20,6 +20,12 @@ namespace UnityEngine.Perception.GroundTruth {
             Color.yellow,
             Color.gray
         };
+
+
+        /// <summary>
+        /// The color to use for the background of semantic segmentation images
+        /// </summary>
+        public Color backgroundColor { get; set; } = Color.black;
     }
 
     /// <summary>

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/SemanticSegmentationCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/SemanticSegmentationCrossPipelinePass.cs
@@ -56,7 +56,7 @@ namespace UnityEngine.Perception.GroundTruth
 
             s_LastFrameExecuted = Time.frameCount;
             var renderList = CreateRendererListDesc(camera, cullingResult, "FirstPass", 0, m_OverrideMaterial, -1);
-            cmd.ClearRenderTarget(true, true, Color.black);
+            cmd.ClearRenderTarget(true, true, m_LabelConfig.backgroundColor);
             DrawRendererList(renderContext, cmd, RendererList.Create(renderList));
         }
 

--- a/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/SemanticSegmentationCrossPipelinePass.cs
+++ b/com.unity.perception/Runtime/GroundTruth/RenderPasses/CrossPipelinePasses/SemanticSegmentationCrossPipelinePass.cs
@@ -56,7 +56,7 @@ namespace UnityEngine.Perception.GroundTruth
 
             s_LastFrameExecuted = Time.frameCount;
             var renderList = CreateRendererListDesc(camera, cullingResult, "FirstPass", 0, m_OverrideMaterial, -1);
-            cmd.ClearRenderTarget(true, true, m_LabelConfig.backgroundColor);
+            cmd.ClearRenderTarget(true, true, m_LabelConfig.skyColor);
             DrawRendererList(renderContext, cmd, RendererList.Create(renderList));
         }
 

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/SegmentationGroundTruthTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/SegmentationGroundTruthTests.cs
@@ -63,6 +63,7 @@ namespace GroundTruthTests
     {
         static readonly Color32 k_SemanticPixelValue = new Color32(10, 20, 30, Byte.MaxValue);
         private static readonly Color32 k_InstanceSegmentationPixelValue = new Color32(255,0,0, 255);
+        private static readonly Color32 k_SkyValue = new Color32(10, 20, 30, 40);
 
         public enum SegmentationKind
         {
@@ -246,7 +247,7 @@ namespace GroundTruthTests
                 CollectionAssert.AreEqual(Enumerable.Repeat(expectedPixelValue, data.Length), data.ToArray());
             }
 
-            var cameraObject = SetupCameraSemanticSegmentation(a => OnSegmentationImageReceived(a.data), false);
+            var cameraObject = SetupCameraSemanticSegmentation(a => OnSegmentationImageReceived(a.data), false, k_SkyValue);
 
             AddTestObjectForCleanup(TestHelper.CreateLabeledPlane(label: "non-matching"));
             yield return null;
@@ -266,7 +267,7 @@ namespace GroundTruthTests
                 CollectionAssert.AreEqual(Enumerable.Repeat(expectedPixelValue, data.Length), data.ToArray());
             }
 
-            var cameraObject = SetupCameraSemanticSegmentation(a => OnSegmentationImageReceived(a.data), false);
+            var cameraObject = SetupCameraSemanticSegmentation(a => OnSegmentationImageReceived(a.data), false, k_SkyValue);
 
             var gameObject = TestHelper.CreateLabeledPlane();
             gameObject.GetComponent<Labeling>().enabled = false;
@@ -300,17 +301,17 @@ namespace GroundTruthTests
         }
 
         [UnityTest]
-        public IEnumerator SemanticSegmentationPass_WithEmptyFrame_ProducesBlack([Values(false, true)] bool showVisualizations)
+        public IEnumerator SemanticSegmentationPass_WithEmptyFrame_ProducesSky([Values(false, true)] bool showVisualizations)
         {
             int timesSegmentationImageReceived = 0;
-            var expectedPixelValue = new Color32(0, 0, 0, 255);
+            var expectedPixelValue = k_SkyValue;
             void OnSegmentationImageReceived(NativeArray<Color32> data)
             {
                 timesSegmentationImageReceived++;
                 CollectionAssert.AreEqual(Enumerable.Repeat(expectedPixelValue, data.Length), data.ToArray());
             }
 
-            var cameraObject = SetupCameraSemanticSegmentation(a => OnSegmentationImageReceived(a.data), showVisualizations);
+            var cameraObject = SetupCameraSemanticSegmentation(a => OnSegmentationImageReceived(a.data), showVisualizations, expectedPixelValue);
 
             //TestHelper.LoadAndStartRenderDocCapture(out var gameView);
             yield return null;
@@ -333,10 +334,10 @@ namespace GroundTruthTests
         }
 
         [UnityTest]
-        public IEnumerator SemanticSegmentationPass_WithNoObjects_ProducesBackground()
+        public IEnumerator SemanticSegmentationPass_WithNoObjects_ProducesSky()
         {
             int timesSegmentationImageReceived = 0;
-            var expectedPixelValue = new Color32(10, 20, 30, 40);
+            var expectedPixelValue = k_SkyValue;
             void OnSegmentationImageReceived(NativeArray<Color32> data)
             {
                 timesSegmentationImageReceived++;
@@ -557,7 +558,7 @@ namespace GroundTruthTests
             });
             if (backgroundColor != null)
             {
-                labelConfig.backgroundColor = backgroundColor.Value;
+                labelConfig.skyColor = backgroundColor.Value;
             }
             var semanticSegmentationLabeler = new SemanticSegmentationLabeler(labelConfig);
             semanticSegmentationLabeler.imageReadback += onSegmentationImageReceived;


### PR DESCRIPTION
# Peer Review Information:
This change adds a sky color to the semantic segmentation labeler.
Note that when this color is changed from the default black, it is no longer considered "background" by the visualizer. I think this is what users will expect, but open to feedback.

Before:
![segmentation_3](https://user-images.githubusercontent.com/23556416/112683565-fbdaea80-8e2e-11eb-9403-2d25bf0ee734.png)

After:
![segmentation_4](https://user-images.githubusercontent.com/23556416/112683501-e36ad000-8e2e-11eb-885c-e5d6c6cdc4d8.png)

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Added**: Added tests for sky coloring

**Core Scenario Tested**: Tested on URP and HDRP

**At Risk Areas**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
- [ ] - Updated test rail
