### PR TITLE
Added first frame skipping back to local editor runs

### DIFF
--- a/com.unity.perception/Runtime/Randomization/Scenarios/PerceptionScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/PerceptionScenario.cs
@@ -20,7 +20,6 @@ namespace UnityEngine.Perception.Randomization.Scenarios
         /// </summary>
         MetricDefinition m_IterationMetricDefinition;
 
-
         /// <summary>
         /// Skip the first simulation frame if not running on Unity simulation
         /// </summary>

--- a/com.unity.perception/Runtime/Randomization/Scenarios/PerceptionScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/PerceptionScenario.cs
@@ -20,6 +20,13 @@ namespace UnityEngine.Perception.Randomization.Scenarios
         /// </summary>
         MetricDefinition m_IterationMetricDefinition;
 
+
+        /// <summary>
+        /// Skip the first frame if not running on Unity simulation
+        /// </summary>
+        protected override bool isScenarioReadyToStart =>
+            !Configuration.Instance.IsSimulationRunningInCloud() && Time.frameCount == 1;
+
         /// <inheritdoc/>
         protected override void OnAwake()
         {

--- a/com.unity.perception/Runtime/Randomization/Scenarios/PerceptionScenario.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/PerceptionScenario.cs
@@ -22,7 +22,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios
 
 
         /// <summary>
-        /// Skip the first frame if not running on Unity simulation
+        /// Skip the first simulation frame if not running on Unity simulation
         /// </summary>
         protected override bool isScenarioReadyToStart =>
             !Configuration.Instance.IsSimulationRunningInCloud() && Time.frameCount == 1;

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using Unity.Simulation;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Perception.Randomization.Parameters;

--- a/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/ScenarioBase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Unity.Simulation;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Perception.Randomization.Parameters;


### PR DESCRIPTION
# Peer Review Information:
This PR adds the first frame check back to the PerceptionScenario to make sure we're skipping the first frame when generating datasets locally.
