### PR TITLE
Poisson disk super sampling

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 Increased color variety in instance segmentation images
 
+The PoissonDiskSampling utility now samples a larger region of points to then crop to size of the intended region to prevent edge case bias.
+
 ### Deprecated
 
 ### Removed

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
@@ -147,9 +147,9 @@ namespace UnityEngine.Perception.Randomization.Randomizers.Utilities
 
             // Calculate occupancy grid dimensions
             var random = new Unity.Mathematics.Random(seed);
-            var cellSize = minimumRadius / math.sqrt(2);
-            var rows = Mathf.FloorToInt(height / cellSize);
-            var cols = Mathf.FloorToInt(width / cellSize);
+            var cellSize = minimumRadius / math.sqrt(2f);
+            var rows = Mathf.CeilToInt(height / cellSize);
+            var cols = Mathf.CeilToInt(width / cellSize);
             var gridSize = rows * cols;
             if (gridSize == 0)
                 return samples;
@@ -167,10 +167,8 @@ namespace UnityEngine.Perception.Randomization.Randomizers.Utilities
             // This list will track all points that may still have space around them for generating new points
             var activePoints = new NativeList<float2>(Allocator.Temp);
 
-            // Randomly place a seed point in a central location within the generation space to kick off the algorithm
-            var firstPoint = new float2(
-                random.NextFloat(0.4f, 0.6f) * width,
-                random.NextFloat(0.4f, 0.6f) * height);
+            // Randomly place a seed point to kick off the algorithm
+            var firstPoint = new float2(random.NextFloat(0f, width), random.NextFloat(0f, height));
             samples.Add(firstPoint);
             var firstPointCol = Mathf.FloorToInt(firstPoint.x / cellSize);
             var firstPointRow = Mathf.FloorToInt(firstPoint.y / cellSize);

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
@@ -121,10 +121,9 @@ namespace UnityEngine.Perception.Randomization.Randomizers.Utilities
                 }
 
                 // Remove the positional offset from the filtered-but-still-super-sampled points
+                var offset = new float2(minimumRadius, minimumRadius);
                 for (var i = 0; i < croppedSamples.Length; i++)
-                {
-                    croppedSamples[i] -= new float2(minimumRadius, minimumRadius);
-                }
+                    croppedSamples[i] -= offset;
 
                 results.Dispose();
             }

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
@@ -103,6 +103,8 @@ namespace UnityEngine.Perception.Randomization.Randomizers.Utilities
                 var results = new NativeArray<bool>(
                     superSampledPoints.Length, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
 
+                // The comparisons operations made in this loop are done separately from the second loop
+                // so that burst can automatically generate vectorized assembly code this portion of the job.
                 for (var i = 0; i < superSampledPoints.Length; i++)
                 {
                     var point = superSampledPoints[i];
@@ -110,6 +112,8 @@ namespace UnityEngine.Perception.Randomization.Randomizers.Utilities
                         && point.y >= minimumRadius && point.y <= height + minimumRadius;
                 }
 
+                // This list-building code is done separately from the filtering loop
+                // because it cannot be vectorized by burst.
                 for (var i = 0; i < superSampledPoints.Length; i++)
                 {
                     if (results[i])

--- a/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
+++ b/com.unity.perception/Runtime/Randomization/Randomizers/RandomizerExamples/Utilities/PoissonDiskSampling.cs
@@ -103,7 +103,7 @@ namespace UnityEngine.Perception.Randomization.Randomizers.Utilities
                 var results = new NativeArray<bool>(
                     superSampledPoints.Length, Allocator.Temp, NativeArrayOptions.UninitializedMemory);
 
-                // The comparisons operations made in this loop are done separately from the second loop
+                // The comparisons operations made in this loop are done separately from the list-building loop
                 // so that burst can automatically generate vectorized assembly code this portion of the job.
                 for (var i = 0; i < superSampledPoints.Length; i++)
                 {
@@ -117,10 +117,13 @@ namespace UnityEngine.Perception.Randomization.Randomizers.Utilities
                 for (var i = 0; i < superSampledPoints.Length; i++)
                 {
                     if (results[i])
-                    {
-                        var p = superSampledPoints[i];
-                        croppedSamples.Add(new float2(p.x - minimumRadius, p.y - minimumRadius));
-                    }
+                        croppedSamples.Add(superSampledPoints[i]);
+                }
+
+                // Remove the positional offset from the filtered-but-still-super-sampled points
+                for (var i = 0; i < croppedSamples.Length; i++)
+                {
+                    croppedSamples[i] -= new float2(minimumRadius, minimumRadius);
                 }
 
                 results.Dispose();


### PR DESCRIPTION
# Peer Review Information:
This PR addresses a problem Bowen found points sampled from the PoissonDiskSampling utility. Before this fix, the utility was generating a distribution of points that was biased toward the edges of the sampling region due to the over-fitting rejection-sampling edge-case behavior of the utility.

To fix this issue, the utility now samples a suitably larger point region and then crops it down to the original intended size to remove all points affected by this edge case behavior.

Finally, there was one final issue, and that was the initial point seeding. The first random point was being placed toward the center of the algorithm to compensate for making the occupancy grid too small (I generated the grid's dimensions with FloorToInt instead of CeilToInt lol). Now, the seed point is correctly placed in a completely random position within the generation region.

Before fix:
![image](https://user-images.githubusercontent.com/53197518/113377517-5ab9cb80-9329-11eb-9607-fbd06ae3ceed.png)
![image](https://user-images.githubusercontent.com/53197518/113376653-0877ab00-9327-11eb-807d-34f1064b9711.png)

After the super sampling fix (I kinda messed up this histogram, but you get the picture):
![image](https://user-images.githubusercontent.com/53197518/113377554-76bd6d00-9329-11eb-8d47-a1bc75048e14.png)
![image](https://user-images.githubusercontent.com/53197518/113376621-f85fcb80-9326-11eb-8e6a-572fd9c5efe1.png)

And after the proper initial point seeding fix:
![image](https://user-images.githubusercontent.com/53197518/113377561-7e7d1180-9329-11eb-8b54-ec15cc2719a7.png)
![image](https://user-images.githubusercontent.com/53197518/113376583-e8e08280-9326-11eb-89f6-cfd1a0a062cd.png)


## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Checklist
- [X] - Updated changelog
