### PR TITLE
Fixing keypoint bugs when visualizations are disabled

### DIFF
--- a/.yamato/environments.yml
+++ b/.yamato/environments.yml
@@ -53,7 +53,7 @@ test_platforms:
     standalone-platform: StandaloneOSX
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:latest
+    image: package-ci/ubuntu:stable
     flavor: b1.large
 
 performance_platforms:
@@ -71,7 +71,7 @@ performance_platforms:
     standalone-platform: StandaloneOSX
   - name: ubuntu
     type: Unity::VM
-    image: package-ci/ubuntu:latest
+    image: package-ci/ubuntu:stable
     flavor: b1.large
 
 performance_suites:


### PR DESCRIPTION
# Peer Review Information:
Keypoints were being mislabeled when visualizations were disabled due to the state of the keypoints being overwritten by frames happening in between simulation and readback.

This change makes a copy of the data before storing it for future use on readback.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Added**:  Added test for new case

**Core Scenario Tested**: Tested keypoints locally and on the PeopleSansPeople project

**At Risk Areas**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
- [ ] - Updated test rail
