### PR TITLE
Fixed issue with simulation delta times larger than 100

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -24,6 +24,8 @@ The PoissonDiskSampling utility now samples a larger region of points to then cr
 
 ### Fixed
 
+Fixed an issue where Simulation Delta Time values larger than 100 seconds (in Perception Camera) would cause incorrect capture scheduling behavior.
+
 ## [0.8.0-preview.3] - 2021-03-24
 ### Changed
 

--- a/com.unity.perception/Editor/GroundTruth/PerceptionCameraEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/PerceptionCameraEditor.cs
@@ -77,7 +77,7 @@ namespace UnityEditor.Perception.GroundTruth
         }
 
         const string k_FrametimeTitle = "Simulation Delta Time";
-
+        const float k_DeltaTimeTooLarge = 200;
         public override void OnInspectorGUI()
         {
             using(new EditorGUI.DisabledScope(EditorApplication.isPlaying))
@@ -93,9 +93,14 @@ namespace UnityEditor.Perception.GroundTruth
                     GUILayout.BeginVertical("TextArea");
                     EditorGUILayout.LabelField("Scheduled Capture Properties", EditorStyles.boldLabel);
 
-                    EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(perceptionCamera.simulationDeltaTime)),new GUIContent(k_FrametimeTitle, $"Sets Unity's Time.{nameof(Time.captureDeltaTime)} to the specified number, causing a fixed number of frames to be simulated for each second of elapsed simulation time regardless of the capabilities of the underlying hardware. Thus, simulation time and real time will not be synchronized."));
+                    EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(perceptionCamera.simulationDeltaTime)),new GUIContent(k_FrametimeTitle, $"Sets Unity's Time.{nameof(Time.captureDeltaTime)} to the specified number, causing a fixed number of frames to be simulated for each second of elapsed simulation time regardless of the capabilities of the underlying hardware. Thus, simulation time and real time will not be synchronized. Note that large {k_FrametimeTitle} values will lead to lower performance as the engine will need to simulate longer periods of elapsed time for each rendered frame."));
                     EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(perceptionCamera.firstCaptureFrame)), new GUIContent("Start at Frame",$"Frame number at which this camera starts capturing."));
                     EditorGUILayout.PropertyField(serializedObject.FindProperty(nameof(perceptionCamera.framesBetweenCaptures)),new GUIContent("Frames Between Captures", "The number of frames to simulate and render between the camera's scheduled captures. Setting this to 0 makes the camera capture every frame."));
+
+                    if (perceptionCamera.simulationDeltaTime > k_DeltaTimeTooLarge)
+                    {
+                        EditorGUILayout.HelpBox($"Large {k_FrametimeTitle} values can lead to significantly lower performance due to the processing time needed for simulating a larger period of time for each rendered frame. ", MessageType.Warning);
+                    }
 
                     var interval = (perceptionCamera.framesBetweenCaptures + 1) * perceptionCamera.simulationDeltaTime;
                     var startTime = perceptionCamera.simulationDeltaTime * perceptionCamera.firstCaptureFrame;

--- a/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
@@ -66,7 +66,6 @@ namespace UnityEngine.Perception.GroundTruth
         const float k_SimulationTimingAccuracy = 0.01f;
         const int k_MinPendingCapturesBeforeWrite = 150;
         const int k_MinPendingMetricsBeforeWrite = 150;
-        const float k_MaxDeltaTime = 100f;
 
         public SimulationState(string outputDirectory)
         {
@@ -473,7 +472,7 @@ namespace UnityEngine.Perception.GroundTruth
             }
 
             //find the deltatime required to land on the next active sensor that needs simulation
-            float nextFrameDt = k_MaxDeltaTime;
+            var nextFrameDt = float.PositiveInfinity;
             foreach (var activeSensor in m_ActiveSensors)
             {
                 float thisSensorNextFrameDt = -1;
@@ -491,10 +490,12 @@ namespace UnityEngine.Perception.GroundTruth
                 }
 
                 if (thisSensorNextFrameDt > 0f && thisSensorNextFrameDt < nextFrameDt)
+                {
                     nextFrameDt = thisSensorNextFrameDt;
+                }
             }
 
-            if (Math.Abs(nextFrameDt - k_MaxDeltaTime) < 0.0001)
+            if (float.IsPositiveInfinity(nextFrameDt))
             {
                 //means no sensor is controlling simulation timing, so we set Time.captureDeltaTime to 0 (default) which means the setting does not do anything
                 nextFrameDt = 0;

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/DatasetCaptureSensorSchedulingTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/DatasetCaptureSensorSchedulingTests.cs
@@ -65,7 +65,7 @@ namespace GroundTruthTests
         {
             var ego = DatasetCapture.RegisterEgo("ego");
             var firstCaptureFrame = 2f;
-            var simulationDeltaTime = .4f;
+            var simulationDeltaTime = 105f;
             var sensorHandle = DatasetCapture.RegisterSensor(ego, "cam", "", firstCaptureFrame, CaptureTriggerMode.Scheduled, simulationDeltaTime, 0);
 
             var startTime = firstCaptureFrame * simulationDeltaTime;
@@ -296,6 +296,39 @@ namespace GroundTruthTests
             }
 
             CollectionAssert.AreEqual(samplesExpected, samplesActual);
+        }
+
+        [UnityTest]
+        [TestCase(1, 0, 0, 1, 2, 3, ExpectedResult = (IEnumerator)null)]
+        [TestCase(10, 5, 50, 60, 70, 80, ExpectedResult = (IEnumerator)null)]
+        [TestCase(55, 0, 0, 55, 110, 165, ExpectedResult = (IEnumerator)null)]
+        [TestCase(235, 10, 2350, 2585, 2820, 3055, ExpectedResult = (IEnumerator)null)]
+        public IEnumerator SequenceTimeOfNextCapture_ReportsCorrectTime_VariedDeltaTimesAndStartFrames(float simulationDeltaTime, int firstCaptureFrame, float firstCaptureTime, float secondCaptureTime, float thirdCaptureTime, float fourthCaptureTime)
+        {
+            var ego = DatasetCapture.RegisterEgo("ego");
+            var sensorHandle = DatasetCapture.RegisterSensor(ego, "cam", "", firstCaptureFrame, CaptureTriggerMode.Scheduled, simulationDeltaTime, 0);
+
+            float[] sequenceTimesExpected =
+            {
+                firstCaptureTime,
+                secondCaptureTime,
+                thirdCaptureTime,
+                fourthCaptureTime
+            };
+
+            for (var i = 0; i < firstCaptureFrame; i++)
+            {
+                //render the non-captured frames before firstCaptureFrame
+                yield return null;
+            }
+
+            for (var i = 0; i < sequenceTimesExpected.Length; i++)
+            {
+                var sensorData = m_TestHelper.GetSensorData(sensorHandle);
+                var sequenceTimeActual = m_TestHelper.CallSequenceTimeOfNextCapture(sensorData);
+                Assert.AreEqual(sequenceTimesExpected[i], sequenceTimeActual, 0.0001f);
+                yield return null;
+            }
         }
 
         [UnityTest]


### PR DESCRIPTION
# Peer Review Information:

This PR fixed an issue where Simulation Delta Time values larger than 100 seconds (in Perception Camera) would cause incorrect capture scheduling behavior. A new test is also added that covers a few different delta time and start frame values.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Added**: 
Yes
**Core Scenario Tested**: 
Unity 2020.3
**At Risk Areas**: 

## Checklist
- [ ] - Updated docs
- [ ] - Updated changelog
- [ ] - Updated test rail
