### PR TITLE
Supporting the 'step' button in the editor

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Known Issues
 
 ### Added
+Added support for 'step' button in editor.
 
 ### Changed
 Increased color variety in instance segmentation images
@@ -23,6 +24,7 @@ The PoissonDiskSampling utility now samples a larger region of points to then cr
 ### Removed
 
 ### Fixed
+Fixed keypoint labeling bug when visualizations are disabled.
 
 ## [0.8.0-preview.3] - 2021-03-24
 ### Changed

--- a/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
+++ b/com.unity.perception/Runtime/GroundTruth/PerceptionCamera.cs
@@ -533,10 +533,7 @@ namespace UnityEngine.Perception.GroundTruth
             // Ignore the subsequent calls.
             if (lastFrameCalledThisCallback == Time.frameCount)
                 return false;
-#if UNITY_EDITOR
-            if (UnityEditor.EditorApplication.isPaused)
-                return false;
-#endif
+
             return true;
         }
 

--- a/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
@@ -452,6 +452,8 @@ namespace UnityEngine.Perception.GroundTruth
                 {
                     //When the user clicks the 'step' button in the editor, frames will always progress at .02 seconds per step.
                     //In this case, just run all sensors each frame to allow for debugging
+                    Debug.Log($"Frame step forced all sensors to synchronize, changing frame timings.");
+
                     sensorData.sequenceTimeOfNextRender = UnscaledSequenceTime;
                     sensorData.sequenceTimeOfNextCapture = UnscaledSequenceTime;
                 }

--- a/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
+++ b/com.unity.perception/Runtime/GroundTruth/SimulationState.cs
@@ -447,6 +447,16 @@ namespace UnityEngine.Perception.GroundTruth
             {
                 var sensorData = m_Sensors[activeSensor];
 
+#if UNITY_EDITOR
+                if (UnityEditor.EditorApplication.isPaused)
+                {
+                    //When the user clicks the 'step' button in the editor, frames will always progress at .02 seconds per step.
+                    //In this case, just run all sensors each frame to allow for debugging
+                    sensorData.sequenceTimeOfNextRender = UnscaledSequenceTime;
+                    sensorData.sequenceTimeOfNextCapture = UnscaledSequenceTime;
+                }
+#endif
+
                 if (Mathf.Abs(sensorData.sequenceTimeOfNextRender - UnscaledSequenceTime) < k_SimulationTimingAccuracy)
                 {
                     //means this frame fulfills this sensor's simulation time requirements, we can move target to next frame.
@@ -460,6 +470,8 @@ namespace UnityEngine.Perception.GroundTruth
                         sensorData.sequenceTimeOfNextCapture += sensorData.renderingDeltaTime * (sensorData.framesBetweenCaptures + 1);
                         Debug.Assert(sensorData.sequenceTimeOfNextCapture > UnscaledSequenceTime,
                             $"Next scheduled capture should be after {UnscaledSequenceTime} but is {sensorData.sequenceTimeOfNextCapture}");
+                        while (sensorData.sequenceTimeOfNextCapture <= UnscaledSequenceTime)
+                            sensorData.sequenceTimeOfNextCapture += sensorData.renderingDeltaTime * (sensorData.framesBetweenCaptures + 1);
                     }
                     else if (sensorData.captureTriggerMode.Equals(CaptureTriggerMode.Manual))
                     {

--- a/com.unity.perception/Tests/Editor/DatasetCaptureEditorTests.cs
+++ b/com.unity.perception/Tests/Editor/DatasetCaptureEditorTests.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.IO;
 using NUnit.Framework;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.Perception.GroundTruth;
 using UnityEngine.TestTools;
@@ -40,6 +41,21 @@ namespace GroundTruthTests
             expectedDatasetPath = DatasetCapture.OutputDirectory;
             yield return new ExitPlayMode();
             FileAssert.Exists(Path.Combine(expectedDatasetPath, "sensors.json"));
+        }
+        [UnityTest]
+        public IEnumerator StepFunction_OverridesSimulationDeltaTime_AndRunsSensors()
+        {
+            yield return new EnterPlayMode();
+            DatasetCapture.ResetSimulation();
+            var ego = DatasetCapture.RegisterEgo("ego");
+            var sensor = DatasetCapture.RegisterSensor(ego, "camera", "", 0, CaptureTriggerMode.Scheduled, 2f, 0);
+            yield return null;
+            var timeBeforeStep = Time.time;
+            EditorApplication.isPaused = true;
+            EditorApplication.Step();
+            Assert.True(Time.time - timeBeforeStep < .3f);
+            Assert.True(sensor.ShouldCaptureThisFrame);
+            yield return new ExitPlayMode();
         }
     }
 }


### PR DESCRIPTION
# Peer Review Information:
This change allows PerceptionCameras to function properly when using the 'step' button in the editor.

The labelers in the PerceptionCamera previously were not even running when using the 'step' button because the editor forces game time to increment at exactly 20ms per frame when using this button. This messed up the timing code in DatasetCapture.

This change detects the use of the step button and forces all sensors to start render and capture each frame. This will not work great with the 'frames between capture' feature, so open to feedback on that one.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Added**: Added editor test for dataset capture while stpping

**Core Scenario Tested**: Tested in editor

**At Risk Areas**: 

## Checklist
- [ ] - Updated docs
- [x] - Updated changelog
- [ ] - Updated test rail
