### PR TITLE
added uint field element for random seeds

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 Added support for 'step' button in editor.
 
+Added random seed field to the Run in Unity Simulation Window
+
 ### Changed
 Increased color variety in instance segmentation images
 

--- a/com.unity.perception/Editor/Randomization/Editors/ScenarioBaseEditor.cs
+++ b/com.unity.perception/Editor/Randomization/Editors/ScenarioBaseEditor.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using UnityEditor.UIElements;
 using UnityEngine;
 using UnityEngine.Perception.Randomization.Scenarios;
 using UnityEngine.UIElements;

--- a/com.unity.perception/Editor/Randomization/PropertyDrawers/UIntDrawer.cs
+++ b/com.unity.perception/Editor/Randomization/PropertyDrawers/UIntDrawer.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using UnityEngine;
+using UnityEngine.UIElements;
+using UnityEditor.UIElements;
+
+namespace UnityEditor.Perception.Randomization.PropertyDrawers
+{
+    [CustomPropertyDrawer(typeof(uint))]
+    class UIntDrawer : PropertyDrawer
+    {
+        public override VisualElement CreatePropertyGUI(SerializedProperty property)
+        {
+            var field = new UIntField
+            {
+                label = property.displayName,
+                bindingPath = property.propertyPath,
+                value = (uint)property.longValue
+            };
+
+            field.RegisterValueChangedCallback(evt =>
+            {
+                field.value = evt.newValue;
+                property.longValue = evt.newValue;
+                property.serializedObject.ApplyModifiedProperties();
+            });
+
+            // Create a surrogate integer field to detect and pass along external change events on the UIntField.
+            // UIElements currently does not support default change detection on non-SerializedProperty supported types.
+            var surrogateField = new IntegerField();
+            field.Add(surrogateField);
+            surrogateField.style.display = new StyleEnum<DisplayStyle>(DisplayStyle.None);
+            surrogateField.bindingPath = property.propertyPath;
+            surrogateField.RegisterValueChangedCallback(evt =>
+            {
+                evt.StopImmediatePropagation();
+                field.value = UIntField.ClampInput(property.longValue);
+            });
+
+            return field;
+        }
+
+        public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+        {
+            EditorGUI.PropertyField(position, property, label, true);
+        }
+
+        public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+        {
+            return EditorGUI.GetPropertyHeight(property);
+        }
+    }
+}

--- a/com.unity.perception/Editor/Randomization/PropertyDrawers/UIntDrawer.cs
+++ b/com.unity.perception/Editor/Randomization/PropertyDrawers/UIntDrawer.cs
@@ -13,10 +13,10 @@ namespace UnityEditor.Perception.Randomization.PropertyDrawers
             var field = new UIntField
             {
                 label = property.displayName,
-                bindingPath = property.propertyPath,
                 value = (uint)property.longValue
             };
 
+            //Binding does not work on this custom UI Element field that we have created, so we need to use the change event
             field.RegisterValueChangedCallback(evt =>
             {
                 field.value = evt.newValue;
@@ -24,11 +24,10 @@ namespace UnityEditor.Perception.Randomization.PropertyDrawers
                 property.serializedObject.ApplyModifiedProperties();
             });
 
-            // Create a surrogate integer field to detect and pass along external change events on the UIntField.
-            // UIElements currently does not support default change detection on non-SerializedProperty supported types.
+            // Create a surrogate integer field to detect and pass along external change events (non UI event) on the underlying serialized property.
             var surrogateField = new IntegerField();
             field.Add(surrogateField);
-            surrogateField.style.display = new StyleEnum<DisplayStyle>(DisplayStyle.None);
+            surrogateField.style.display = DisplayStyle.Flex;
             surrogateField.bindingPath = property.propertyPath;
             surrogateField.RegisterValueChangedCallback(evt =>
             {

--- a/com.unity.perception/Editor/Randomization/PropertyDrawers/UIntDrawer.cs.meta
+++ b/com.unity.perception/Editor/Randomization/PropertyDrawers/UIntDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e363a3910d78fe943b8f50b68a2d2fb9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/Uxml/RunInUnitySimulationWindow.uxml
+++ b/com.unity.perception/Editor/Randomization/Uxml/RunInUnitySimulationWindow.uxml
@@ -8,6 +8,12 @@
                 tooltip="The number of scenario iterations to execute"/>
             <editor:IntegerField name="instance-count" label="Instance Count" max-value="10000"
                 tooltip="The number of instances to distribute the work load across"/>
+            <VisualElement style="flex-direction: row;">
+                <editor:UIntField name="random-seed" label="Random Seed" style="flex-grow: 1;"
+                                     tooltip="The initial random seed to use for the simulation"/>
+                <Button name="randomize-seed" text="Randomize"/>
+            </VisualElement>
+
             <VisualElement class="unity-base-field"
                            tooltip="The compute resources configuration to execute the simulation with">
                 <Label text="Sys-Param" class="unity-base-field__label"/>
@@ -30,10 +36,12 @@
             <Label name="prev-run-name" text="Run Name: " class="sim-window__label-prev-result"/>
             <Label name="project-id" text="Project ID: " class="sim-window__label-prev-result"/>
             <Label name="execution-id" text="Execution ID: " class="sim-window__label-prev-result"/>
+            <Label name="prev-random-seed" text="Random Seed: " class="sim-window__label-prev-result"/>
 
             <VisualElement style="flex-direction: row; margin-top: 2px;">
                 <Button name="copy-execution-id" text="Copy Execution ID" style="flex-grow: 1; flex-shrink: 0;"/>
                 <Button name="copy-project-id" text="Copy Project ID" style="flex-grow: 1; flex-shrink: 0;"/>
+                <Button name="copy-prev-random-seed" text="Copy Seed" style="flex-grow: 1; flex-shrink: 0;"/>
             </VisualElement>
         </VisualElement>
     </VisualElement>

--- a/com.unity.perception/Editor/Randomization/VisualElements/Basic.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Basic.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 93e88a2d53dd88f42ae287310c2a6ca3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Basic/UIntField.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Basic/UIntField.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Globalization;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+namespace UnityEditor.UIElements
+{
+    /// <summary>
+    ///     <para>Makes a text field for entering an unsigned integer.</para>
+    /// </summary>
+    public class UIntField : TextValueField<uint>
+    {
+        /// <summary>
+        ///     <para>USS class name of elements of this type.</para>
+        /// </summary>
+        public new static readonly string ussClassName = "unity-uint-field";
+        /// <summary>
+        ///     <para>USS class name of labels in elements of this type.</para>
+        /// </summary>
+        public new static readonly string labelUssClassName = ussClassName + "__label";
+        /// <summary>
+        ///     <para>USS class name of input elements in elements of this type.</para>
+        /// </summary>
+        public new static readonly string inputUssClassName = ussClassName + "__input";
+
+        /// <summary>
+        ///     <para>Constructor.</para>
+        /// </summary>
+        public UIntField()
+            : this(null) { }
+
+        /// <summary>
+        ///     <para>Constructor.</para>
+        /// </summary>
+        /// <param name="maxLength">Maximum number of characters the field can take.</param>
+        public UIntField(int maxLength)
+            : this(null, maxLength) { }
+
+        public UIntField(string label, int maxLength = -1)
+            : base(label, maxLength, new UIntInput())
+        {
+            AddToClassList(ussClassName);
+            labelElement.AddToClassList(labelUssClassName);
+            labelElement.AddToClassList("unity-property-field__label");
+            AddLabelDragger<uint>();
+        }
+
+        UIntInput uIntInput => (UIntInput)textInputBase;
+
+        /// <summary>
+        ///     <para>Converts the given uint to a string.</para>
+        /// </summary>
+        /// <param name="v">The uint to be converted to string.</param>
+        /// <returns>
+        ///     <para>The uint as string.</para>
+        /// </returns>
+        protected override string ValueToString(uint v)
+        {
+            return v.ToString(formatString, CultureInfo.InvariantCulture.NumberFormat);
+        }
+
+        /// <summary>
+        ///     <para>Converts a string to an uint.</para>
+        /// </summary>
+        /// <param name="str">The string to convert.</param>
+        /// <returns>
+        ///     <para>The uint parsed from the string.</para>
+        /// </returns>
+        protected override uint StringToValue(string str)
+        {
+            long.TryParse(str, out var result);
+            return ClampInput(result);
+        }
+
+        /// <summary>
+        ///     <para>Modify the value using a 3D delta and a speed, typically coming from an input device.</para>
+        /// </summary>
+        /// <param name="delta">A vector used to compute the value change.</param>
+        /// <param name="speed">A multiplier for the value change.</param>
+        /// <param name="startValue">The start value.</param>
+        public override void ApplyInputDeviceDelta(Vector3 delta, DeltaSpeed speed, uint startValue)
+        {
+            uIntInput.ApplyInputDeviceDelta(delta, speed, startValue);
+        }
+
+        /// <summary>
+        ///     <para>Instantiates an UIntField using the data read from a UXML file.</para>
+        /// </summary>
+        public new class UxmlFactory : UxmlFactory<UIntField, UxmlTraits> { }
+
+        /// <summary>
+        ///     <para>Defines UxmlTraits for the UIntField.</para>
+        /// </summary>
+        public new class UxmlTraits : TextValueFieldTraits<uint, UxmlUIntAttributeDescription> { }
+
+        public static uint ClampInput(long input)
+        {
+            input = input > uint.MaxValue ? uint.MaxValue : input;
+            input = input < uint.MinValue ? uint.MinValue : input;
+            return (uint)input;
+        }
+
+        class UIntInput : TextValueInput
+        {
+            internal UIntInput()
+            {
+                formatString = "#######0";
+            }
+
+            UIntField parentUIntField => (UIntField)parent;
+
+            protected override string allowedCharacters => "0123456789";
+
+            public override void ApplyInputDeviceDelta(Vector3 delta, DeltaSpeed speed, uint startValue)
+            {
+                var num = StringToValue(text) + (long)Math.Round(delta.x);
+                var value = ClampInput(num);
+                if (parentUIntField.isDelayed)
+                    text = ValueToString(value);
+                else
+                    parentUIntField.value = value;
+            }
+
+            protected override string ValueToString(uint v)
+            {
+                return v.ToString(formatString);
+            }
+
+            protected override uint StringToValue(string str)
+            {
+                long.TryParse(str, out var result);
+                return ClampInput(result);
+            }
+        }
+    }
+}

--- a/com.unity.perception/Editor/Randomization/VisualElements/Basic/UIntField.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Basic/UIntField.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64ee321fd1c586b4a9dbfc0f7da230be
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.perception/Editor/Randomization/VisualElements/Basic/UxmlUIntAttributeDescription.cs
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Basic/UxmlUIntAttributeDescription.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Globalization;
+
+namespace UnityEngine.UIElements
+{
+    /// <summary>
+    ///     <para>Describes a XML int attribute.</para>
+    /// </summary>
+    public class UxmlUIntAttributeDescription : TypedUxmlAttributeDescription<uint>
+    {
+        /// <summary>
+        ///     <para>Constructor.</para>
+        /// </summary>
+        public UxmlUIntAttributeDescription()
+        {
+            type = "int";
+            typeNamespace = "http://www.w3.org/2001/XMLSchema";
+            defaultValue = 0;
+        }
+
+        /// <summary>
+        ///     <para>The default value for the attribute, as a string.</para>
+        /// </summary>
+        public override string defaultValueAsString => defaultValue.ToString(CultureInfo.InvariantCulture.NumberFormat);
+
+        /// <summary>
+        ///     <para>
+        ///         Retrieves the value of this attribute from the attribute bag. Returns it if it is found, otherwise return
+        ///         defaultValue.
+        ///     </para>
+        /// </summary>
+        /// <param name="bag">The bag of attributes.</param>
+        /// <param name="cc">The context in which the values are retrieved.</param>
+        /// <returns>
+        ///     <para>The value of the attribute.</para>
+        /// </returns>
+        public override uint GetValueFromBag(IUxmlAttributes bag, CreationContext cc)
+        {
+            return GetValueFromBag(bag, cc, (s, i) => ConvertValueToUInt(s, i), defaultValue);
+        }
+
+        public bool TryGetValueFromBag(IUxmlAttributes bag, CreationContext cc, ref uint value)
+        {
+            return TryGetValueFromBag(bag, cc, (s, i) => ConvertValueToUInt(s, i), defaultValue, ref value);
+        }
+
+        static uint ConvertValueToUInt(string v, uint defaultValue)
+        {
+            return v == null || !uint.TryParse(v, out uint result) ? defaultValue : result;
+        }
+    }
+}

--- a/com.unity.perception/Editor/Randomization/VisualElements/Basic/UxmlUIntAttributeDescription.cs.meta
+++ b/com.unity.perception/Editor/Randomization/VisualElements/Basic/UxmlUIntAttributeDescription.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e94e3964dd6654488e74ca218f23111
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Peer Review Information:
This PR adds a new UIntField UI element to enable users to configure the full range of random-seeds possible for their scenarios. Before this PR, the scenario's random seed constant (stored as an unsigned integer) was represented by an integer field that limited the potential seed values that could be assigned to the scenario and also introduced serialization issues when negative seed values were entered.

In addition, a randomize-seed button was also added to the Run in Unity Simulation window so users can quickly modify their scenario's random seed between runs.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
No tests were added, though I will need to update the test rail to confirm the changes made in this PR.

## Checklist
- [X] - Updated changelog
- [ ] - Updated test rail
