### PR TITLE
changed normal sampler standard deviation json key to "stddev"

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -23,6 +23,8 @@ The PoissonDiskSampling utility now samples a larger region of points to then cr
 
 Upgraded capture package dependency to 0.0.10-preview.22 to fix an issue with URP where post processing effects were not included when capturing images.
 
+Changed the JSON serialization key of Normal Sampler's standard deviation property from "standardDeviation" to "stddev". Scneario JSON configurations that were generated using previous versions will need to be manually updated to reflect this change.
+
 ### Deprecated
 
 ### Removed

--- a/com.unity.perception/Runtime/Randomization/Scenarios/Serialization/ScenarioSerializer.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/Serialization/ScenarioSerializer.cs
@@ -136,7 +136,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios.Serialization
                     min = normalSampler.range.minimum,
                     max = normalSampler.range.maximum,
                     mean = normalSampler.mean,
-                    standardDeviation = normalSampler.standardDeviation
+                    stddev = normalSampler.standardDeviation
                 };
             else
                 throw new ArgumentException($"Invalid sampler type ({sampler.GetType()})");
@@ -245,7 +245,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios.Serialization
                         maximum = (float)normalSampler.max
                     },
                     mean = (float)normalSampler.mean,
-                    standardDeviation = (float)normalSampler.standardDeviation
+                    standardDeviation = (float)normalSampler.stddev
                 };
             throw new ArgumentException($"Cannot deserialize unsupported sampler type {samplerOption.GetType()}");
         }

--- a/com.unity.perception/Runtime/Randomization/Scenarios/Serialization/SerializationStructures.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/Serialization/SerializationStructures.cs
@@ -59,7 +59,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios.Serialization
         public double min;
         public double max;
         public double mean;
-        public double standardDeviation;
+        public double stddev;
     }
 
     class ConstantSampler : ISamplerOption


### PR DESCRIPTION
# Peer Review Information:

The Datamaker service expects this key to be "stddev" instead of "standardDeviation". It looks like making the change here has fewer ramifications than on Datamaker. 

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

## Checklist
- [ ] - Updated docs
- [x] - Updated changelog
- [ ] - Updated test rail
