### PR TITLE
Categorical parameter fix

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -34,6 +34,8 @@ Fixed keypoint labeling bug when visualizations are disabled.
 
 Fixed an issue where Simulation Delta Time values larger than 100 seconds (in Perception Camera) would cause incorrect capture scheduling behavior.
 
+Fixed an issue where Categorical Parameters sometimes tried to fetch items at `i = categories.Count`, which caused an exception.
+
 ## [0.8.0-preview.3] - 2021-03-24
 ### Changed
 

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
@@ -175,9 +175,17 @@ namespace UnityEngine.Perception.Randomization.Parameters
         public T Sample()
         {
             var randomValue = m_Sampler.Sample();
-            return uniform
-                ? m_Categories[(int)(randomValue * m_Categories.Count)]
-                : m_Categories[BinarySearch(randomValue)];
+            if (uniform)
+            {
+                var index = (int)(randomValue * m_Categories.Count);
+                if (index == m_Categories.Count)
+                {
+                    index--;
+                }
+
+                return m_Categories[index];
+            }
+            return m_Categories[BinarySearch(randomValue)];
         }
 
         /// <summary>

--- a/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
+++ b/com.unity.perception/Runtime/Randomization/Parameters/CategoricalParameter.cs
@@ -178,11 +178,7 @@ namespace UnityEngine.Perception.Randomization.Parameters
             if (uniform)
             {
                 var index = (int)(randomValue * m_Categories.Count);
-                if (index == m_Categories.Count)
-                {
-                    index--;
-                }
-
+                index = index == m_Categories.Count ? index - 1 : index;
                 return m_Categories[index];
             }
             return m_Categories[BinarySearch(randomValue)];


### PR DESCRIPTION
# Peer Review Information:

Fixed an issue where categorical parameters sometimes tried to fetch items at i = categories.count, leading to an exception.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

## Checklist
- [ ] - Updated docs
- [x] - Updated changelog
- [ ] - Updated test rail
