### PR TITLE
Fixed an indexing issue with the Id Label Config editor

### DIFF
--- a/TestProjects/PerceptionURP/Assets/Tests/Editor/PerceptionCameraEditorUrpTests.cs
+++ b/TestProjects/PerceptionURP/Assets/Tests/Editor/PerceptionCameraEditorUrpTests.cs
@@ -41,6 +41,8 @@ namespace EditorTests
             var gameObject = new GameObject();
             gameObject.SetActive(false);
             gameObject.AddComponent<Camera>();
+            gameObject.AddComponent<UniversalAdditionalCameraData>();
+            
             var perceptionCamera = gameObject.AddComponent<PerceptionCamera>();
             gameObject.SetActive(true);
             LogAssert.Expect(LogType.Error, "GroundTruthRendererFeature must be present on the ScriptableRenderer associated with the camera. The ScriptableRenderer can be accessed through Edit -> Project Settings... -> Graphics -> Scriptable Render Pipeline Settings -> Renderer List.");

--- a/TestProjects/PerceptionURP/Packages/packages-lock.json
+++ b/TestProjects/PerceptionURP/Packages/packages-lock.json
@@ -81,7 +81,7 @@
         "com.unity.collections": "0.9.0-preview.6",
         "com.unity.nuget.newtonsoft-json": "1.1.2",
         "com.unity.render-pipelines.core": "7.1.6",
-        "com.unity.simulation.capture": "0.0.10-preview.20",
+        "com.unity.simulation.capture": "0.0.10-preview.23",
         "com.unity.simulation.client": "0.0.10-preview.10",
         "com.unity.simulation.core": "0.0.10-preview.22"
       }
@@ -115,11 +115,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.simulation.capture": {
-      "version": "0.0.10-preview.20",
+      "version": "0.0.10-preview.23",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.simulation.core": "0.0.10-preview.22"
+        "com.unity.simulation.core": "0.0.10-preview.25"
       },
       "url": "https://packages.unity.com"
     },
@@ -131,10 +131,12 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.simulation.core": {
-      "version": "0.0.10-preview.22",
-      "depth": 1,
+      "version": "0.0.10-preview.25",
+      "depth": 2,
       "source": "registry",
-      "dependencies": {},
+      "dependencies": {
+        "com.unity.nuget.newtonsoft-json": "2.0.0-preview"
+      },
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {

--- a/TestProjects/PerceptionURP/Packages/packages-lock.json
+++ b/TestProjects/PerceptionURP/Packages/packages-lock.json
@@ -81,7 +81,7 @@
         "com.unity.collections": "0.9.0-preview.6",
         "com.unity.nuget.newtonsoft-json": "1.1.2",
         "com.unity.render-pipelines.core": "7.1.6",
-        "com.unity.simulation.capture": "0.0.10-preview.23",
+        "com.unity.simulation.capture": "0.0.10-preview.20",
         "com.unity.simulation.client": "0.0.10-preview.10",
         "com.unity.simulation.core": "0.0.10-preview.22"
       }
@@ -115,11 +115,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.simulation.capture": {
-      "version": "0.0.10-preview.23",
+      "version": "0.0.10-preview.20",
       "depth": 1,
       "source": "registry",
       "dependencies": {
-        "com.unity.simulation.core": "0.0.10-preview.25"
+        "com.unity.simulation.core": "0.0.10-preview.22"
       },
       "url": "https://packages.unity.com"
     },
@@ -131,12 +131,10 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.simulation.core": {
-      "version": "0.0.10-preview.25",
-      "depth": 2,
+      "version": "0.0.10-preview.22",
+      "depth": 1,
       "source": "registry",
-      "dependencies": {
-        "com.unity.nuget.newtonsoft-json": "2.0.0-preview"
-      },
+      "dependencies": {},
       "url": "https://packages.unity.com"
     },
     "com.unity.test-framework": {

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -63,7 +63,6 @@ Fixed an issue where Simulation Delta Time values larger than 100 seconds in Per
 
 Fixed an issue where Categorical Parameters sometimes tried to fetch items at `i = categories.Count`, which caused an exception.
 
-
 ## [0.8.0-preview.3] - 2021-03-24
 ### Changed
 

--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -12,33 +12,55 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Known Issues
 
 ### Added
-Added support for 'step' button in editor.
-
-Added random seed field to the Run in Unity Simulation Window
 
 User can now choose the base folder location to store their generated data.
 
-Added 'projection' field in the capture.sensor metadata. Values are either "perspective" or "orthographic"
+Added a `projection` field in the capture.sensor metadata. Values are either "perspective" or "orthographic".
 
 ### Changed
-Increased color variety in instance segmentation images
 
-The PoissonDiskSampling utility now samples a larger region of points to then crop to size of the intended region to prevent edge case bias.
-
-Upgraded capture package dependency to 0.0.10-preview.22 to fix an issue with URP where post processing effects were not included when capturing images.
-
-Changed the JSON serialization key of Normal Sampler's standard deviation property from "standardDeviation" to "stddev". Scneario JSON configurations that were generated using previous versions will need to be manually updated to reflect this change.
+Changed the JSON serialization key of Normal Sampler's standard deviation property from "standardDeviation" to "stddev". Scenario JSON configurations that were generated using previous versions will need to be manually updated to reflect this change.
 
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+Fixed an indexing issue with the IdLabelConfig editor. When a new label was added to an empty Id Label Config with Auto Assign IDs enabled, the starting id (0 or 1) was ignored and the new label would always have an id of 0.
+
+## [0.8.0-preview.4] - 2021-07-05
+
+### Upgrade Notes
+
+### Known Issues
+
+### Added
+
+Added support for 'step' button in editor.
+
+Added random seed field to the Run in Unity Simulation Window.
+
+### Changed
+
+Increased color variety in instance segmentation images.
+
+The PoissonDiskSampling utility now samples a larger region of points to then crop to size of the intended region to prevent edge case bias.
+
+Upgraded capture package dependency to 0.0.10-preview.23 to fix two issues: (1) Post processing effects were not included when capturing images in URP (2) RGB images were upside-down when post processing effects were enabled and FXAA disabled.
+
+### Deprecated
+
+### Removed
+
+### Fixed
+
 Fixed keypoint labeling bug when visualizations are disabled.
 
-Fixed an issue where Simulation Delta Time values larger than 100 seconds (in Perception Camera) would cause incorrect capture scheduling behavior.
+Fixed an issue where Simulation Delta Time values larger than 100 seconds in Perception Camera would cause incorrect capture scheduling behavior.
 
 Fixed an issue where Categorical Parameters sometimes tried to fetch items at `i = categories.Count`, which caused an exception.
+
 
 ## [0.8.0-preview.3] - 2021-03-24
 ### Changed

--- a/com.unity.perception/Editor/GroundTruth/IdLabelConfigEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/IdLabelConfigEditor.cs
@@ -149,14 +149,22 @@ namespace UnityEditor.Perception.GroundTruth
         protected override IdLabelEntry CreateLabelEntryFromLabelString(SerializedProperty serializedArray,
             string labelToAdd)
         {
-            int maxLabel = Int32.MinValue;
+            var maxLabel = int.MinValue;
             if (serializedArray.arraySize == 0)
                 maxLabel = -1;
 
-            for (int i = 0; i < serializedArray.arraySize; i++)
+            for (var i = 0; i < serializedArray.arraySize; i++)
             {
                 var item = serializedArray.GetArrayElementAtIndex(i);
                 maxLabel = math.max(maxLabel, item.FindPropertyRelative(nameof(IdLabelEntry.id)).intValue);
+            }
+
+            if (maxLabel == -1)
+            {
+                var startingLabelId =
+                    (StartingLabelId) serializedObject.FindProperty(nameof(IdLabelConfig.startingLabelId)).enumValueIndex;
+                if (startingLabelId == StartingLabelId.One)
+                    maxLabel = 0;
             }
 
             return new IdLabelEntry

--- a/com.unity.perception/package.json
+++ b/com.unity.perception/package.json
@@ -4,7 +4,7 @@
     "com.unity.collections": "0.9.0-preview.6",
     "com.unity.nuget.newtonsoft-json": "1.1.2",
     "com.unity.render-pipelines.core": "7.1.6",
-    "com.unity.simulation.capture": "0.0.10-preview.22",
+    "com.unity.simulation.capture": "0.0.10-preview.23",
     "com.unity.simulation.client": "0.0.10-preview.10",
     "com.unity.simulation.core": "0.0.10-preview.22"
   },
@@ -12,7 +12,7 @@
   "displayName": "Perception",
   "name": "com.unity.perception",
   "unity": "2019.4",
-  "version": "0.8.0-preview.3",
+  "version": "0.8.0-preview.4",
   "samples": [
     {
       "displayName": "Tutorial Files",


### PR DESCRIPTION
# Peer Review Information:

- Bug: When a new label was added to an empty id label config, the starting id (0 or 1) was ignored and the new label would always have an id of 0.

- Realized changelog was not updated after preview.4 release. Added a section for that release and modified the unreleased section accordingly.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

## Checklist
- [ ] - Updated docs
- [x] - Updated changelog
- [ ] - Updated test rail
