### PR TITLE
Updated serialization of randomizers to an array of groups

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -23,7 +23,9 @@ Added a `projection` field in the capture.sensor metadata. Values are either "pe
 
 ### Changed
 
-Changed the JSON serialization key of Normal Sampler's standard deviation property from "standardDeviation" to "stddev". Scneario JSON configurations that were generated using previous versions will need to be manually updated to reflect this change.
+Scenario JSON configurations that were generated using previous versions will need to be manually updated to reflect the following changes:
+ - Changed the JSON serialization key of Normal Sampler's standard deviation property from "standardDeviation" to "stddev".
+ - Changed the JSON serialization of randomizers in a scenario to an array of groups rather than a dictionary.
 
 ### Deprecated
 

--- a/com.unity.perception/Runtime/Randomization/Scenarios/Serialization/ScenarioSerializer.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/Serialization/ScenarioSerializer.cs
@@ -54,15 +54,16 @@ namespace UnityEngine.Perception.Randomization.Scenarios.Serialization
             };
         }
 
-        static Dictionary<string, Group> SerializeRandomizers(IEnumerable<Randomizer> randomizers)
+        static List<Group> SerializeRandomizers(IEnumerable<Randomizer> randomizers)
         {
-            var serializedRandomizers = new Dictionary<string, Group>();
+            var serializedRandomizers = new List<Group>();
             foreach (var randomizer in randomizers)
             {
                 var randomizerData = SerializeRandomizer(randomizer);
                 if (randomizerData.items.Count == 0)
                     continue;
-                serializedRandomizers.Add(randomizer.GetType().Name, randomizerData);
+
+                serializedRandomizers.Add(randomizerData);
             }
             return serializedRandomizers;
         }
@@ -71,6 +72,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios.Serialization
         {
             var randomizerData = new Group();
             var fields = randomizer.GetType().GetFields();
+            randomizerData.className = randomizer.GetType().Name;
             foreach (var field in fields)
             {
                 if (field.FieldType.IsSubclassOf(typeof(Randomization.Parameters.Parameter)))
@@ -178,18 +180,18 @@ namespace UnityEngine.Perception.Randomization.Scenarios.Serialization
             DeserializeRandomizers(scenario.randomizers, template.groups);
         }
 
-        static void DeserializeRandomizers(IEnumerable<Randomizer> randomizers, Dictionary<string, Group> groups)
+        static void DeserializeRandomizers(IEnumerable<Randomizer> randomizers, List<Group> groups)
         {
             var randomizerTypeMap = new Dictionary<string, Randomizer>();
             foreach (var randomizer in randomizers)
                 randomizerTypeMap.Add(randomizer.GetType().Name, randomizer);
 
-            foreach (var randomizerPair in groups)
+            foreach (var randomizerData in groups)
             {
-                if (!randomizerTypeMap.ContainsKey(randomizerPair.Key))
+                if (!randomizerTypeMap.ContainsKey(randomizerData.className))
                     continue;
-                var randomizer = randomizerTypeMap[randomizerPair.Key];
-                DeserializeRandomizer(randomizer, randomizerPair.Value);
+                var randomizer = randomizerTypeMap[randomizerData.className];
+                DeserializeRandomizer(randomizer, randomizerData);
             }
         }
 

--- a/com.unity.perception/Runtime/Randomization/Scenarios/Serialization/SerializationStructures.cs
+++ b/com.unity.perception/Runtime/Randomization/Scenarios/Serialization/SerializationStructures.cs
@@ -16,7 +16,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios.Serialization
     #region GroupedObjects
     class TemplateConfigurationOptions
     {
-        public Dictionary<string, Group> groups = new Dictionary<string, Group>();
+        public List<Group> groups = new List<Group>();
     }
 
     class StandardMetadata
@@ -28,6 +28,7 @@ namespace UnityEngine.Perception.Randomization.Scenarios.Serialization
 
     class Group
     {
+        public string className;
         public StandardMetadata metadata = new StandardMetadata();
         [JsonConverter(typeof(GroupItemsConverter))]
         public Dictionary<string, IGroupItem> items = new Dictionary<string, IGroupItem>();

--- a/com.unity.perception/Tests/Runtime/Randomization/ScenarioTests/Resources/SampleScenarioConfiguration.json
+++ b/com.unity.perception/Tests/Runtime/Randomization/ScenarioTests/Resources/SampleScenarioConfiguration.json
@@ -7,8 +7,9 @@
     "randomSeed": 539662031
   },
   "randomizers": {
-    "groups": {
-      "RotationRandomizer": {
+    "groups": [
+      {
+        "className": "RotationRandomizer",
         "metadata": {
           "name": "",
           "description": "",
@@ -67,6 +68,6 @@
           }
         }
       }
-    }
+    ]
   }
 }


### PR DESCRIPTION
# Peer Review Information:
Changed how randomizers are serialized from a dictionary of string (randomizer type name) ➡️ group to a list of groups with an additional `className` field which contains the randomizer type name. This should fix issues with inconsistent ordering when deserializing externally.

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Updated**: 
- `ScenarioConfigurationSerializesProperly` and the dependent resource `SampleScenarioConfiguration`

## Checklist
- [ ] - Updated docs
- [x] - Updated changelog
- [ ] - Updated test rail
