### PR TITLE
Updated documentation for 3dbbox about skinnedmeshrenderers

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -35,6 +35,8 @@ Changed the JSON serialization key of Normal Sampler's standard deviation proper
 
 Fixed an indexing issue with the IdLabelConfig editor. When a new label was added to an empty Id Label Config with Auto Assign IDs enabled, the starting id (0 or 1) was ignored and the new label would always have an id of 0.
 
+Updated documentation to reflect that the 3D bounding box labeler does not support skinned mesh renderer types
+
 ## [0.8.0-preview.4] - 2021-07-05
 
 ### Upgrade Notes

--- a/com.unity.perception/Documentation~/FAQ/FAQ.md
+++ b/com.unity.perception/Documentation~/FAQ/FAQ.md
@@ -68,6 +68,13 @@ This is due to a common graphics problem called *z-fighting*. This occurs when t
 ---
 </details>
 
+<details>
+  <summary><strong>Q: Why aren't my character models labeled by the 3D Bounding Box Labeler?</strong></summary><br>
+
+Most human character models use skinned mesh renderers. Unfortunately, at this time, gameobjects using skinned mesh renderers are not supported by the 3D Bounding Box Labeler.
+
+---
+</details>
 
 ## <a name="randomization">Randomization</a>
 

--- a/com.unity.perception/Documentation~/PerceptionCamera.md
+++ b/com.unity.perception/Documentation~/PerceptionCamera.md
@@ -66,7 +66,8 @@ The BoundingBox2DLabeler produces 2D bounding boxes for each visible object with
 
 ### Bounding Box 3D Labeler
 
-The Bounding Box 3D Ground Truth Labeler produces 3D ground truth bounding boxes for each labeled game object in the scene. Unlike the 2D bounding boxes, 3D bounding boxes are calculated from the labeled meshes in the scene and all objects (independent of their occlusion state) are recorded.
+The Bounding Box 3D Ground Truth Labeler produces 3D ground truth bounding boxes for each labeled game object in the scene. Unlike the 2D bounding boxes, 3D bounding boxes are calculated from the labeled meshes in the scene and all objects (independent of their occlusion state) are recorded.  
+***Note:*** The Bounding Box 3D Labeler does not support SkinnedMeshRenderer gameobjects, they will be ignored
 
 ### Object Count Labeler
 

--- a/com.unity.perception/Runtime/GroundTruth/Labelers/BoundingBox3DLabeler.cs
+++ b/com.unity.perception/Runtime/GroundTruth/Labelers/BoundingBox3DLabeler.cs
@@ -12,6 +12,7 @@ namespace UnityEngine.Perception.GroundTruth
     /// <summary>
     /// Produces 3d bounding box ground truth for all visible and <see cref="Labeling"/> objects each frame.
     /// </summary>
+    /// <remarks>The BoundingBox3DLabeler does not support <see cref="SkinnedMeshRenderer"/> objects, they will be ignored.</remarks>
     public class BoundingBox3DLabeler : CameraLabeler
     {
         ///<inheritdoc/>


### PR DESCRIPTION
# Peer Review Information:
Updated documentation to address that skinned mesh renderers are not supported by 3D bounding box labeler

## Editor / Package versioning:
**Editor Version Target**: 2019.4

## Dev Testing:
**Tests Added**: 

**Core Scenario Tested**: 

**At Risk Areas**: 

## Checklist
- [x] - Updated docs
- [x] - Updated changelog
- [x] - Updated test rail
