### PR TITLE
Fix incorrect animation playback speed (x7 instead of x1)

### DIFF
--- a/com.unity.perception/Runtime/GroundTruth/Resources/AnimationRandomizerController.controller
+++ b/com.unity.perception/Runtime/GroundTruth/Resources/AnimationRandomizerController.controller
@@ -52,7 +52,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: RandomState
-  m_Speed: 7
+  m_Speed: 1
   m_CycleOffset: 0
   m_Transitions: []
   m_StateMachineBehaviours: []


### PR DESCRIPTION
Fixes issue #552 by restoring AnimatorController RandomState speed parameter to x1.