### PR TITLE
Steve/instance aggregation

### DIFF
--- a/com.unity.perception/CHANGELOG.md
+++ b/com.unity.perception/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Upgrade Notes
 
 ### Added
+Added support for hierarchical label aggregation in instance segmentation labeler
 
 ### Changed
 

--- a/com.unity.perception/Editor/GroundTruth/LabelConfigEditor.cs
+++ b/com.unity.perception/Editor/GroundTruth/LabelConfigEditor.cs
@@ -135,7 +135,7 @@ namespace UnityEditor.Perception.GroundTruth
             m_AddNewLabelButton.clicked += () => { AddNewLabel(m_AddedLabels); };
 
 #if UNITY_2020_1_OR_NEWER
-            m_LabelListView.onSelectionChange +=  UpdateMoveButtonState;
+            m_LabelListView.selectionChanged +=  UpdateMoveButtonState;
 #else
             m_LabelListView.onSelectionChanged +=  UpdateMoveButtonState;
 #endif

--- a/com.unity.perception/Editor/Unity.Perception.Editor.api
+++ b/com.unity.perception/Editor/Unity.Perception.Editor.api
@@ -80,7 +80,7 @@ namespace UnityEngine.Perception.Settings
 
 namespace UnityEngine.Perception.UIElements
 {
-    public class UIntField : UnityEditor.UIElements.TextValueField<System.UInt32>
+    public class UIntField : UnityEngine.UIElements.TextValueField<System.UInt32>
     {
         public static readonly string inputUssClassName;
         public static readonly string labelUssClassName;
@@ -88,7 +88,7 @@ namespace UnityEngine.Perception.UIElements
         public UIntField() {}
         public UIntField(int maxLength) {}
         public UIntField(string label, int maxLength = -1) {}
-        public override void ApplyInputDeviceDelta(Vector3 delta, UnityEditor.UIElements.DeltaSpeed speed, System.UInt32 startValue);
+        public override void ApplyInputDeviceDelta(Vector3 delta, UnityEngine.UIElements.DeltaSpeed speed, System.UInt32 startValue);
         public static System.UInt32 ClampInput(long input);
         protected override System.UInt32 StringToValue(string str);
         protected override string ValueToString(System.UInt32 v);
@@ -96,7 +96,7 @@ namespace UnityEngine.Perception.UIElements
         {
             public UxmlFactory() {}
         }
-        public class UxmlTraits : UnityEditor.UIElements.TextValueFieldTraits<System.UInt32, UxmlUIntAttributeDescription>
+        public class UxmlTraits : UnityEngine.UIElements.TextValueFieldTraits<System.UInt32, UxmlUIntAttributeDescription>
         {
             public UxmlTraits() {}
         }

--- a/com.unity.perception/Runtime/GroundTruth/LabelManagement/IdLabelConfig.cs
+++ b/com.unity.perception/Runtime/GroundTruth/LabelManagement/IdLabelConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;

--- a/com.unity.perception/Runtime/Unity.Perception.Runtime.api
+++ b/com.unity.perception/Runtime/Unity.Perception.Runtime.api
@@ -867,6 +867,7 @@ namespace UnityEngine.Perception.GroundTruth.Labelers
 
     [UnityEngine.Scripting.APIUpdating.MovedFrom(@"UnityEngine.Perception.GroundTruth")] public sealed class InstanceSegmentationLabeler : CameraLabeler, IOverlayPanelProvider
     {
+        [Tooltip(@"Should the instance segmentation capture the single instance of the parent gameobject, or the individual sub-components")] public bool aggregateChildren = false;
         [Tooltip(@"The id to associate with instance segmentation annotations in the dataset.")] public string annotationId = @"instance segmentation";
         public UnityEngine.Perception.GroundTruth.LabelManagement.IdLabelConfig idLabelConfig;
         public System.Action<int, Unity.Collections.NativeArray<Color32>, RenderTexture> imageReadback;

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/InstanceSegmentationHierarchyTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/InstanceSegmentationHierarchyTests.cs
@@ -1,0 +1,194 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.Perception.GroundTruth;
+using UnityEngine.Perception.GroundTruth.Labelers;
+using UnityEngine.Perception.GroundTruth.LabelManagement;
+using UnityEngine.TestTools;
+
+namespace GroundTruthTests
+{
+    [TestFixture]
+    public class InstanceSegmentationHierarchyTests : GroundTruthTestBase
+    {
+        IEnumerator ExecuteTest(bool aggregate, List<InstanceSegmentationEntry> expected)
+        {
+            Screen.SetResolution(640, 480, false);
+            yield return null;
+
+            var labelingConfiguration = CreateLabelingConfiguration();
+            var labeler = new InstanceSegmentationLabeler(labelingConfiguration)
+            {
+                aggregateChildren = aggregate
+            };
+
+            var camera = SetupCamera(pc =>
+            {
+                pc.AddLabeler(labeler);
+            });
+
+            var collector = new CollectEndpoint();
+            DatasetCapture.OverrideEndpoint(collector);
+            DatasetCapture.ResetSimulation();
+
+            CreateSceneComponents();
+
+            yield return null;
+            DatasetCapture.ResetSimulation();
+
+            Assert.AreEqual(1, collector.currentRun.frames.Count);
+            var f = collector.currentRun.frames.First();
+            Assert.NotNull(f);
+
+            Assert.AreEqual(1, f.sensors.Count);
+            var s = f.sensors[0];
+            Assert.NotNull(s);
+
+            Assert.AreEqual(1, s.annotations.Count);
+            var annotation = s.annotations[0];
+            Assert.NotNull(annotation);
+
+            Assert.AreEqual("type.unity.com/unity.solo.InstanceSegmentationAnnotation", annotation.modelType);
+            var instanceAnnotation = (InstanceSegmentationAnnotation)annotation;
+            Assert.NotNull(instanceAnnotation);
+
+            var instances = instanceAnnotation.instances.ToList();
+            Assert.NotNull(instances);
+            Assert.AreEqual(expected.Count, instances.Count);
+
+            foreach (var e in expected)
+            {
+                var tList = instances.Where(x => x.labelId == e.labelId);
+                Assert.NotNull(tList);
+
+                Assert.AreEqual(1, tList.Count());
+                var t = tList.First();
+
+                Assert.AreEqual(e.labelId, t.labelId);
+                Assert.AreEqual(e.labelName, t.labelName);
+            }
+        }
+
+        [UnityTest]
+        public IEnumerator InstanceSegmentation_Hierarchy_AggregationOn()
+        {
+            var expected = new List<InstanceSegmentationEntry>
+            {
+                new()
+                {
+                    labelId = 1,
+                    labelName = "the_big_one"
+                }
+            };
+
+            return ExecuteTest(true, expected);
+        }
+
+        [UnityTest]
+        public IEnumerator InstanceSegmentation_Hierarchy_AggregationOff()
+        {
+            var expected = new List<InstanceSegmentationEntry>
+            {
+                new()
+                {
+                    labelId = 2,
+                    labelName = "box1"
+                },
+                new()
+                {
+                    labelId = 3,
+                    labelName = "box2"
+                },
+                new()
+                {
+                    labelId = 4,
+                    labelName = "box3"
+                },
+                new()
+                {
+                    labelId = 5,
+                    labelName = "box4"
+                }
+            };
+
+            return ExecuteTest(false, expected);
+        }
+
+        GameObject CreateSceneComponents()
+        {
+            var go = new GameObject("Props");
+            AddTestObjectForCleanup(go);
+
+            var theBigOne = new GameObject("the_big_one");
+            AddTestObjectForCleanup(theBigOne);
+            theBigOne.transform.position = new Vector3(0, 1.17f, 0);
+            theBigOne.transform.localScale = new Vector3(0.5f, 0.5f, 0.5f);
+            theBigOne.AddComponent<Labeling>().labels.Add("the_big_one");
+            theBigOne.transform.parent = go.transform;
+
+            var box1 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            AddTestObjectForCleanup(box1);
+            box1.transform.parent = theBigOne.transform;
+            box1.transform.localPosition = new Vector3(-0.5f, -1f, 0);
+            box1.AddComponent<Labeling>().labels.Add("box1");
+
+            var box2 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            AddTestObjectForCleanup(box2);
+            box2.transform.parent = theBigOne.transform;
+            box2.transform.localPosition = new Vector3(0.75f, -1f, 0);
+            box2.AddComponent<Labeling>().labels.Add("box2");
+
+            var box3 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            AddTestObjectForCleanup(box3);
+            box3.transform.parent = theBigOne.transform;
+            box3.transform.localPosition = new Vector3(0.75f, 0.5f, 0);
+            box3.AddComponent<Labeling>().labels.Add("box3");
+
+            var box4 = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            AddTestObjectForCleanup(box4);
+            box4.transform.parent = theBigOne.transform;
+            box4.transform.localPosition = new Vector3(-0.5f, 0.5f, 0);
+            box4.AddComponent<Labeling>().labels.Add("box4");
+
+            return go;
+        }
+
+        static IdLabelConfig CreateLabelingConfiguration()
+        {
+            var labelConfig = ScriptableObject.CreateInstance<IdLabelConfig>();
+
+            labelConfig.Init(new List<IdLabelEntry>
+            {
+                new()
+                {
+                    id = 1,
+                    label = "the_big_one"
+                },
+                new()
+                {
+                    id = 2,
+                    label = "box1"
+                },
+                new()
+                {
+                    id = 3,
+                    label = "box2"
+                },
+                new()
+                {
+                    id = 4,
+                    label = "box3"
+                },
+                new()
+                {
+                    id = 5,
+                    label = "box4"
+                }
+            });
+
+            return labelConfig;
+        }
+    }
+}

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/InstanceSegmentationHierarchyTests.cs.meta
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/InstanceSegmentationHierarchyTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: e2e903be2e804ef693dfefd674945cf3
+timeCreated: 1673564817

--- a/com.unity.perception/Tests/Runtime/GroundTruthTests/SoloFormatTests.cs
+++ b/com.unity.perception/Tests/Runtime/GroundTruthTests/SoloFormatTests.cs
@@ -10,6 +10,7 @@ using UnityEngine.Perception.GroundTruth.Consumers;
 using UnityEngine.Perception.GroundTruth.DataModel;
 using UnityEngine.Perception.GroundTruth.Labelers;
 using UnityEngine.Perception.GroundTruth.LabelManagement;
+using UnityEngine.Perception.GroundTruth.Utilities;
 using UnityEngine.TestTools;
 
 namespace GroundTruthTests
@@ -748,6 +749,8 @@ namespace GroundTruthTests
             var annDesc = "Produces an instance segmentation image for each frame. The image will render the pixels of each labeled object in a distinct color.";
 
             var instanceId = cube.GetComponent<Labeling>().instanceId;
+            var color = InstanceIdToColorMapping.GetColorFromInstanceId(instanceId);
+
 
             var instances = new JArray
             {
@@ -756,7 +759,7 @@ namespace GroundTruthTests
                     { "instanceId", instanceId },
                     { "labelId", 1 },
                     { "labelName", "test" },
-                    { "color", new JArray { 255, 0, 0, 255 } }
+                    { "color", new JArray { color.r, color.g, color.b, color.a } }
                 }
             };
 


### PR DESCRIPTION
Modified instance segmentation labeler to support aggregating children into a parent's instance segmentation result. This capability is built on changes made recently to labeling to support hierarchical label definitions. Now when a user requests to aggregate the results, all of the sub-components will be considered the same instance of an object. If a user selects to not aggregate their results, then each sub-component will be considered a distinct instance of an object.